### PR TITLE
Version inference from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ build_html = "2.4.0"
 byteorder = "1.5.0"
 cesu8 = "1.1.0"
 chrono = "0.4.38"
-clap = { version = "4.5.4", features = ["derive", "env"] }
+clap = { version = "4.5.4", features = ["cargo", "derive", "env"] }
 cookie = "0.17.0"
 cookie_store = "0.20.0"
 ctrlc = "3.4.4"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -283,13 +283,13 @@ impl Commands {
 
 /// PartialConfiguration is a representation of a fuzzer configuration, obtained from the
 /// CLI or from a configuration file.
-/// 
+///
 /// Partial configurations are only one source, e.g. config file or command line.
 /// You can't make any field mandatory, since then they all need to be specified in both places,
 /// which is counterproductive. The Configuration is combined from the two (many?) Partials
 /// and does have mandatory fields. Therefore creating a Configuration from a PartialConfiguration
 /// using TryFrom can fail.
-/// 
+///
 #[derive(Debug, Default, PartialEq, Eq, Deserialize, Parser)]
 struct PartialConfiguration {
     /// The path to the open api specification of the target. The specification must

--- a/src/initial_corpus/dependency_graph/mod.rs
+++ b/src/initial_corpus/dependency_graph/mod.rs
@@ -5,7 +5,6 @@ mod toposort;
 /// as input to other requests (GET artist?id=1). To know which outputs to use for which inputs,
 /// you need a graph that connects possible requests/operations (nodes) by parameters that carry
 /// the same meaning (edges). The dependency graph module attempts to build such a graph.
-
 use std::{
     cmp::Ordering,
     collections::{hash_map::DefaultHasher, HashMap},

--- a/src/input/parameter.rs
+++ b/src/input/parameter.rs
@@ -14,11 +14,11 @@ use super::new_rand_input;
 /// Structs that help describe parameters to HTTP requests in a way that the fuzzer can still
 /// mutate and reason about. The ParameterKind enum describes the places a parameter can occur
 /// (query, header etc.);
-/// 
+///
 /// the Kind together with the parameter name must be unique within a request/operation.
 /// The ParameterContents enum describes the different kinds of value a parameter can take,
 /// e.g. an array, or a string, or a reference to the output of a previous request.
-/// 
+///
 /// See also: dependency graph module
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,7 +26,7 @@ use libafl_bolts::{
 };
 
 /// OpenApiFuzzerState is an object needed by LibAFL.
-/// 
+///
 /// We have a bespoke one so we're able to pass the api spec to mutators,
 /// which get a reference to the state object as argument to the mutate method.
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/wuppie_version.rs
+++ b/src/wuppie_version.rs
@@ -1,10 +1,6 @@
 use std::env;
 use std::process::Command;
 
-// Important: This line is referenced in tbump.toml.
-// Keep any changes in sync with the tbump.toml expression.
-const TBUMP_VERSION: &str = "0.34.2";
-
 pub fn get_wuppie_version() -> String {
     let git_output = Command::new("git").arg("rev-parse").arg("HEAD").output();
     let git_hash = match git_output {
@@ -21,7 +17,7 @@ pub fn get_wuppie_version() -> String {
         Err(_) => "<could not get git hash>".to_string(),
     };
 
-    TBUMP_VERSION.to_string() + &git_hash
+    clap::crate_version!().to_string() + &git_hash
 }
 
 pub fn print_version() {


### PR DESCRIPTION
Infer the version number from `Cargo.toml` instead of having it hard-coded in multiple places.