### PR TITLE
Feat regex anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   [#29](https://github.com/TNO-S3/WuppieFuzz/pull/29)
 - Added support for all remaining HTTP methods (options, connect) in
   [#32](https://github.com/TNO-S3/WuppieFuzz/pull/32)
+- Added support for Regex anchors
 
 # v1.1.0 (2024-09-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added support for all remaining HTTP methods (options, connect) in
   [#32](https://github.com/TNO-S3/WuppieFuzz/pull/32)
 - Added support for Regex anchors
+  [#35](https://github.com/TNO-S3/WuppieFuzz/pull/35)
 
 # v1.1.0 (2024-09-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1835,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -3114,6 +3114,7 @@ dependencies = [
  "porter-stemmer",
  "rand",
  "rand_regex",
+ "regex",
  "reqwest",
  "reqwest_cookie_store",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ petgraph = "0.6.4"
 porter-stemmer = "0.1.2"
 rand = "0.8.5"
 rand_regex = "0.17.0"
+regex = "1.11.1"
 reqwest = { version = "0.12.4", features = ["blocking", "json"] }
 reqwest_cookie_store = "0.7.0"
 rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/SBOM.txt
+++ b/SBOM.txt
@@ -526,13 +526,13 @@ ratatui 0.26.3
 redox_syscall 0.5.4
 	licensed under "MIT"
 	by Jeremy Soller <jackpot51@gmail.com>
-regex 1.10.6
+regex 1.11.1
 	licensed under "Apache-2.0 OR MIT"
 	by The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
-regex-automata 0.4.7
+regex-automata 0.4.8
 	licensed under "Apache-2.0 OR MIT"
 	by The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
-regex-syntax 0.8.4
+regex-syntax 0.8.5
 	licensed under "Apache-2.0 OR MIT"
 	by The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
 reqwest 0.12.7


### PR DESCRIPTION
Added support for Regex anchors. This is implemented as a fall-back in case the default non-anchor regex check fails.