### PR TITLE
removed libssl and added build-essential to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Features
 
 ## Fixes
+- Removed `libssl` from installation prerequisites and added `build-essential` in
+  [#45](https://github.com/TNO-S3/WuppieFuzz/pull/45)
 
 # v1.1.1 (2024-11-06)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ WuppieFuzz was featured in
 
 To run the project you need to install the following dependencies and tooling
 
-- libssl-dev `sudo apt install libssl-dev`
+- build-essential `sudo apt install build-essential`
 - pkg-config `sudo apt install pkg-config`
 - Rust `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 


### PR DESCRIPTION
libssl is no longer needed because it is linked during compilation.
build-essential is needed to use `cc` as a linker