### PR TITLE
Ugly workaround for #46

### DIFF
--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -336,9 +336,18 @@ pub fn fuzz() -> Result<()> {
         .map(|timeout| Instant::now() - starting_time < timeout)
         .unwrap_or(true)
     {
-        fuzzer
-            .fuzz_one(&mut stages, &mut executor, &mut state, &mut mgr)
-            .context("Error in the fuzzing loop")?;
+        match fuzzer
+            .fuzz_one(&mut stages, &mut executor, &mut state, &mut mgr) {
+                Ok(res) => res,
+                Err(err) => match err {
+                    libafl_bolts::Error::ShuttingDown => {
+                        return Ok(());
+                    }
+                    _ => {
+                        panic!("Error in the fuzz loop.");
+                    }
+                }
+            };
         // send update of execution data to the monitor
         let executions = *state.executions();
         if let Err(e) = mgr.fire(

--- a/src/state.rs
+++ b/src/state.rs
@@ -39,6 +39,8 @@ pub struct OpenApiFuzzerState<I, C, R, SC> {
     rand: R,
     /// How many times the executor ran the harness/target
     executions: u64,
+    /// Request to stop
+    stop_requested: bool,
     /// At what time the fuzzing started
     start_time: Duration,
     /// The corpus
@@ -111,14 +113,16 @@ where
     Self: UsesInput,
 {
     fn stop_requested(&self) -> bool {
-        false
+        self.stop_requested
     }
 
     fn request_stop(&mut self) {
-        todo!("Stopping not implemented")
+        self.stop_requested = true;
     }
 
-    fn discard_stop_request(&mut self) {}
+    fn discard_stop_request(&mut self) {
+        self.stop_requested = false;
+    }
 }
 
 impl<I, C, R, SC> HasRand for OpenApiFuzzerState<I, C, R, SC>
@@ -360,6 +364,7 @@ where
         let mut state = Self {
             rand,
             executions: 0,
+            stop_requested: false,
             start_time: Duration::from_millis(0),
             metadata: SerdeAnyMap::default(),
             named_metadata: NamedSerdeAnyMap::default(),


### PR DESCRIPTION
Closes #46 

@grebnetiew, getting our own executor seems more and more relevant to make our code stable and comprehensible..

Ideally we would move all this logic (including catching crtl+c and (near instant) exiting) to such executor.