### PR TITLE
Add Sigrid configuration file

### DIFF
--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -1,0 +1,58 @@
+languages:
+  - name: Rust
+
+components:
+  - name: Authentication
+    include:
+      - ".*/authentication/.*"
+  - name: Coverage-Clients
+    include:
+      - ".*/coverage_clients/.*"
+  - name: Initial-Corpus
+    include:
+      - ".*/initial_corpus/.*"
+  - name: Input
+    include:
+      - ".*/input/.*"
+  - name: OpenAPI
+    include:
+      - ".*/openapi/.*"
+  - name: OpenAPI-Mutator
+    include:
+      - ".*/openapi_mutator/.*"
+  - name: Reporting
+    include:
+      - ".*/reporting/.*"
+  - name: Configuration
+    include:
+      - ".*/configuration\.rs"
+  - name: Debug-Writer
+    include:
+      - ".*/debug_writer\.rs"
+  - name: Executor
+    include:
+      - ".*/executor\.rs"
+  - name: Fuzzer
+    include:
+      - ".*/fuzzer\.rs"
+  - name: Header
+    include:
+      - ".*/herader\.rs"
+  - name: Main
+    include:
+      - ".*/main\.rs"
+  - name: Montiors
+    include:
+      - ".*/monitors\.rs"
+  - name: Parameter-Feedback
+    include:
+      - ".*/parameter_feedback\.rs"
+  - name: Reproducer
+    include:
+      - ".*/reproducer\.rs"
+  - name: State
+    include:
+      - ".*/state\.rs"
+  - name: Wuppie-Version
+    include:
+      - ".*/wuppie_version\.rs"

--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -78,3 +78,9 @@ architecture:
         - openapi
         - initial-corpus
       annotation: "Modules handling REST API related complexity"
+    - name: "HTTP infrastructure"
+      include:
+        - authentication
+        - header
+        - parameter_feedback
+      annotation: "Modules handling REST API related complexity"

--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -56,3 +56,25 @@ components:
   - name: wuppie-version
     include:
       - ".*/wuppie_version\.rs"
+
+architecture:
+  grouping:
+    - name: "Entry points"
+      include:
+        - fuzzer
+        - reproducer
+        - wuppie-version
+      annotation: "Modules providing main functionality of the application"
+    - name: "LibAFL Components"
+      include:
+        - state
+        - executor
+        - monitors
+        - openapi-mutator
+        - input
+      annotation: "Specializations of LibAFL components"
+    - name: "OpenAPI infrastructure"
+      include:
+        - openapi
+        - initial-corpus
+      annotation: "Modules handling REST API related complexity"

--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -2,57 +2,57 @@ languages:
   - name: Rust
 
 components:
-  - name: Authentication
+  - name: authentication
     include:
       - ".*/authentication/.*"
-  - name: Coverage-Clients
+  - name: coverage-clients
     include:
       - ".*/coverage_clients/.*"
-  - name: Initial-Corpus
+  - name: initial-corpus
     include:
       - ".*/initial_corpus/.*"
-  - name: Input
+  - name: input
     include:
       - ".*/input/.*"
-  - name: OpenAPI
+  - name: openapi
     include:
       - ".*/openapi/.*"
-  - name: OpenAPI-Mutator
+  - name: openapi-mutator
     include:
       - ".*/openapi_mutator/.*"
-  - name: Reporting
+  - name: reporting
     include:
       - ".*/reporting/.*"
-  - name: Configuration
+  - name: configuration
     include:
       - ".*/configuration\.rs"
-  - name: Debug-Writer
+  - name: debug-writer
     include:
       - ".*/debug_writer\.rs"
-  - name: Executor
+  - name: executor
     include:
       - ".*/executor\.rs"
-  - name: Fuzzer
+  - name: fuzzer
     include:
       - ".*/fuzzer\.rs"
-  - name: Header
+  - name: header
     include:
       - ".*/herader\.rs"
-  - name: Main
+  - name: main
     include:
       - ".*/main\.rs"
-  - name: Montiors
+  - name: montiors
     include:
       - ".*/monitors\.rs"
-  - name: Parameter-Feedback
+  - name: parameter-feedback
     include:
       - ".*/parameter_feedback\.rs"
-  - name: Reproducer
+  - name: reproducer
     include:
       - ".*/reproducer\.rs"
-  - name: State
+  - name: state
     include:
       - ".*/state\.rs"
-  - name: Wuppie-Version
+  - name: wuppie-version
     include:
       - ".*/wuppie_version\.rs"

--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -25,37 +25,37 @@ components:
       - ".*/reporting/.*"
   - name: configuration
     include:
-      - ".*/configuration\.rs"
+      - ".*/configuration[.]rs"
   - name: debug-writer
     include:
-      - ".*/debug_writer\.rs"
+      - ".*/debug_writer[.]rs"
   - name: executor
     include:
-      - ".*/executor\.rs"
+      - ".*/executor[.]rs"
   - name: fuzzer
     include:
-      - ".*/fuzzer\.rs"
+      - ".*/fuzzer[.]rs"
   - name: header
     include:
-      - ".*/herader\.rs"
+      - ".*/herader[.]rs"
   - name: main
     include:
-      - ".*/main\.rs"
+      - ".*/main[.]rs"
   - name: montiors
     include:
-      - ".*/monitors\.rs"
+      - ".*/monitors[.]rs"
   - name: parameter-feedback
     include:
-      - ".*/parameter_feedback\.rs"
+      - ".*/parameter_feedback[.]rs"
   - name: reproducer
     include:
-      - ".*/reproducer\.rs"
+      - ".*/reproducer[.]rs"
   - name: state
     include:
-      - ".*/state\.rs"
+      - ".*/state[.]rs"
   - name: wuppie-version
     include:
-      - ".*/wuppie_version\.rs"
+      - ".*/wuppie_version[.]rs"
 
 architecture:
   grouping:


### PR DESCRIPTION
Adds configuraton that specifies all Rust modules as components, and adds several semantic groups of modules.

