### PR TITLE
feat: Add support for power schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Features
 
+- Adds support for setting power schedules for seed scheduling in
+  [#73](https://github.com/TNO-S3/WuppieFuzz/pull/73)
 - Adds custom executor enabling proper timeout kill and removing unsafe code in
   [#49](https://github.com/TNO-S3/WuppieFuzz/pull/49)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "backtrace",
  "bincode",
  "bitbybit",
+ "clap",
  "const_format",
  "const_panic",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ iter-read = "1.0.1"
 json_env_logger2 = "0.2.1"
 lazy_static = "1.4.0"
 lcov = "0.8"
-libafl = "=0.15.0"
+libafl = { version = "=0.15.0", features = ["clap"] }
 libafl_bolts = { version = "=0.15.0", features = ["prelude"] }
 log = { version = "0.4.25", features = ["serde"] }
 num = { version = "0.4.2", default-features = false }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -143,7 +143,7 @@ pub enum Commands {
         #[arg(value_parser, long)]
         request_timeout: Option<u64>,
 
-        /// Set the power schedule to use. Defaults to EXPLOIT.
+        /// Set the power schedule to use. Defaults to FAST.
         #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]
         power_schedule: Option<BaseSchedule>,
 
@@ -332,7 +332,7 @@ struct PartialConfiguration {
     #[clap(value_parser, long)]
     pub request_timeout: Option<u64>,
 
-    /// Set the power schedule to use. Defaults to EXPLOIT.
+    /// Set the power schedule to use. Defaults to FAST.
     #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]
     pub power_schedule: Option<BaseSchedule>,
 
@@ -574,7 +574,7 @@ impl TryFrom<PartialConfiguration> for Configuration {
             },
             timeout: value.timeout,
             request_timeout: value.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT),
-            power_schedule: value.power_schedule.unwrap_or(BaseSchedule::EXPLOIT),
+            power_schedule: value.power_schedule.unwrap_or(BaseSchedule::FAST),
             crash_criterion: value.crash_criterion.unwrap_or(CrashCriterion::AllErrors),
             report: value.report.unwrap_or(false),
             method_mutation_strategy: value

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -143,7 +143,7 @@ pub enum Commands {
         #[arg(value_parser, long)]
         request_timeout: Option<u64>,
 
-        /// Set the power schedule to use. Defaults to FAST.
+        /// Set the power schedule to use. Defaults to EXPLOIT.
         #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]
         power_schedule: Option<BaseSchedule>,
 
@@ -332,7 +332,7 @@ struct PartialConfiguration {
     #[clap(value_parser, long)]
     pub request_timeout: Option<u64>,
 
-    /// Set the power schedule to use. Defaults to FAST.
+    /// Set the power schedule to use. Defaults to EXPLOIT.
     #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]
     pub power_schedule: Option<BaseSchedule>,
 
@@ -574,7 +574,7 @@ impl TryFrom<PartialConfiguration> for Configuration {
             },
             timeout: value.timeout,
             request_timeout: value.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT),
-            power_schedule: value.power_schedule.unwrap_or(BaseSchedule::FAST),
+            power_schedule: value.power_schedule.unwrap_or(BaseSchedule::EXPLOIT),
             crash_criterion: value.crash_criterion.unwrap_or(CrashCriterion::AllErrors),
             report: value.report.unwrap_or(false),
             method_mutation_strategy: value

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -134,7 +134,11 @@ pub fn fuzz() -> Result<()> {
     // A minimization+queue policy to get testcases from the corpus
     let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &combined_map_observer,
-        PowerQueueScheduler::new(&mut state, &combined_map_observer, PowerSchedule::fast()),
+        PowerQueueScheduler::new(
+            &mut state,
+            &combined_map_observer,
+            PowerSchedule::new(config.power_schedule),
+        ),
     );
 
     // A fuzzer with feedbacks and a corpus scheduler


### PR DESCRIPTION
This enables support for setting power schedules for seed prioritization.

@cristiandaniele would be interesting if you could benchmark which of the strategies is the most sensible default.

Possible values:

          - explore: The `explore` power schedule
          - exploit: The `exploit` power schedule
          - fast:    The `fast` power schedule
          - coe:     The `coe` power schedule
          - lin:     The `lin` power schedule
          - quad:    The `quad` power schedule