### PR TITLE
Mutator tests

### DIFF
--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -113,3 +113,33 @@ fn field_names(api: &OpenAPI, request_body: &RequestBody) -> Option<Vec<String>>
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod test {
+    use libafl::mutators::{MutationResult, Mutator};
+
+    use crate::{input::{Method, OpenApiInput}, state::tests::TestOpenApiFuzzerState};
+
+    use super::AddRequestMutator;
+
+    /// Tests whether the mutator adds a valid request (including parameters, if required for the chosen request).
+    #[test]
+    fn add_correct_request() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut input = OpenApiInput(vec![]);
+            let mut mutator = AddRequestMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+            assert_eq!(input.0.len(), 1);
+            assert!(TestOpenApiFuzzerState::PATHS.contains(&input.0[0].path.as_str()));
+            assert!(input.0[0].method == Method::Get || (input.0[0].path == "/simple" && input.0[0].method == Method::Delete));
+            if input.0[0].path == "/with-query-parameter" || input.0[0].path == "/with-path-parameter/{id}" {
+                assert!(input.0[0].contains_parameter("id"));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/openapi_mutator/break_link.rs
+++ b/src/openapi_mutator/break_link.rs
@@ -59,3 +59,57 @@ where
         Ok(MutationResult::Mutated)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use indexmap::IndexMap;
+    use libafl::mutators::{MutationResult, Mutator};
+
+    use crate::{
+        input::{parameter::ParameterKind, Body, Method, OpenApiInput, OpenApiRequest, ParameterContents},
+        state::tests::TestOpenApiFuzzerState,
+    };
+
+    use super::BreakLinkMutator;
+
+    /// Tests whether the mutator correctly breaks a reference parameter.
+    #[test]
+    fn break_link() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut parameters = IndexMap::new();
+            parameters.insert(
+                ("id".to_string(), ParameterKind::Query),
+                ParameterContents::Reference {
+                    request_index: 1,
+                    parameter_name: "id".to_string(),
+                },
+            );
+            let has_param = OpenApiRequest {
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
+                body: Body::Empty,
+                parameters,
+            };
+
+            let has_return_value = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![has_return_value, has_param]);
+            let mut mutator = BreakLinkMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+            assert!(input.0[1]
+                .get_mut_parameter("id", ParameterKind::Query)
+                .expect("Could not find parameter after request removal")
+                .bytes()
+                .is_some());
+        }
+        Ok(())
+    }
+}

--- a/src/openapi_mutator/different_method.rs
+++ b/src/openapi_mutator/different_method.rs
@@ -128,22 +128,23 @@ mod test {
     /// when using MethodMutationStrategy::Common5.
     #[test]
     fn different_method_common5() -> anyhow::Result<()> {
-        let mut state = TestOpenApiFuzzerState::new();
-        let test_request = OpenApiRequest {
-            method: Method::Get,
-            path: "/simple".to_string(),
-            body: Body::Empty,
-            parameters: IndexMap::new(),
-        };
-        let mut input = OpenApiInput(vec![test_request]);
-        let mut mutator = DifferentMethodMutator {
-            method_mutation_strategy: MethodMutationStrategy::Common5,
-        };
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let test_request = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+            let mut input = OpenApiInput(vec![test_request]);
+            let mut mutator = DifferentMethodMutator {
+                method_mutation_strategy: MethodMutationStrategy::Common5,
+            };
 
-        mutator.mutate(&mut state, &mut input)?;
+            mutator.mutate(&mut state, &mut input)?;
 
-        assert_ne!(input.0[0].method, Method::Get);
-
+            assert_ne!(input.0[0].method, Method::Get);
+        }
         Ok(())
     }
 
@@ -151,21 +152,23 @@ mod test {
     /// when using MethodMutationStrategy::FollowSpec.
     #[test]
     fn different_method_follow_spec() -> anyhow::Result<()> {
-        let mut state = TestOpenApiFuzzerState::new();
-        let test_request = OpenApiRequest {
-            method: Method::Get,
-            path: "/simple".to_string(),
-            body: Body::Empty,
-            parameters: IndexMap::new(),
-        };
-        let mut input = OpenApiInput(vec![test_request]);
-        let mut mutator = DifferentMethodMutator {
-            method_mutation_strategy: MethodMutationStrategy::FollowSpec,
-        };
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let test_request = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+            let mut input = OpenApiInput(vec![test_request]);
+            let mut mutator = DifferentMethodMutator {
+                method_mutation_strategy: MethodMutationStrategy::FollowSpec,
+            };
 
-        mutator.mutate(&mut state, &mut input)?;
+            mutator.mutate(&mut state, &mut input)?;
 
-        assert_eq!(input.0[0].method, Method::Delete);
+            assert_eq!(input.0[0].method, Method::Delete);
+        }
 
         Ok(())
     }

--- a/src/openapi_mutator/different_method.rs
+++ b/src/openapi_mutator/different_method.rs
@@ -58,7 +58,8 @@ where
 
         let random_input = rand.choose(&mut input.0).unwrap();
 
-        let available_methods: Vec<(&str, Option<usize>)> = match self.method_mutation_strategy {
+        let mut available_methods: Vec<(&str, Option<usize>)> = match self.method_mutation_strategy
+        {
             MethodMutationStrategy::FollowSpec => {
                 // Find the operations in the API with this input's path, and select one
                 // with a different method than the current input's method, if available
@@ -87,6 +88,8 @@ where
             ],
         };
 
+        available_methods
+            .retain(|&(method, _)| !method.eq_ignore_ascii_case(&random_input.method.to_string()));
         if available_methods.is_empty() {
             return Ok(MutationResult::Skipped);
         }

--- a/src/openapi_mutator/different_method.rs
+++ b/src/openapi_mutator/different_method.rs
@@ -110,3 +110,63 @@ where
         Ok(MutationResult::Mutated)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use indexmap::IndexMap;
+    use libafl::mutators::Mutator;
+
+    use crate::{
+        configuration::MethodMutationStrategy,
+        input::{Body, Method, OpenApiInput, OpenApiRequest},
+        state::tests::TestOpenApiFuzzerState,
+    };
+
+    use super::DifferentMethodMutator;
+
+    /// Tests whether the mutator correctly assigns a different method when using
+    /// when using MethodMutationStrategy::Common5.
+    #[test]
+    fn different_method_common5() -> anyhow::Result<()> {
+        let mut state = TestOpenApiFuzzerState::new();
+        let test_request = OpenApiRequest {
+            method: Method::Get,
+            path: "/simple".to_string(),
+            body: Body::Empty,
+            parameters: IndexMap::new(),
+        };
+        let mut input = OpenApiInput(vec![test_request]);
+        let mut mutator = DifferentMethodMutator {
+            method_mutation_strategy: MethodMutationStrategy::Common5,
+        };
+
+        mutator.mutate(&mut state, &mut input)?;
+
+        assert_ne!(input.0[0].method, Method::Get);
+
+        Ok(())
+    }
+
+    /// Tests whether the mutator correctly assigns a different method within the spec
+    /// when using MethodMutationStrategy::FollowSpec.
+    #[test]
+    fn different_method_follow_spec() -> anyhow::Result<()> {
+        let mut state = TestOpenApiFuzzerState::new();
+        let test_request = OpenApiRequest {
+            method: Method::Get,
+            path: "/simple".to_string(),
+            body: Body::Empty,
+            parameters: IndexMap::new(),
+        };
+        let mut input = OpenApiInput(vec![test_request]);
+        let mut mutator = DifferentMethodMutator {
+            method_mutation_strategy: MethodMutationStrategy::FollowSpec,
+        };
+
+        mutator.mutate(&mut state, &mut input)?;
+
+        assert_eq!(input.0[0].method, Method::Delete);
+
+        Ok(())
+    }
+}

--- a/src/openapi_mutator/different_path.rs
+++ b/src/openapi_mutator/different_path.rs
@@ -95,22 +95,25 @@ mod test {
     /// Tests whether the mutator correctly changes the path of a request.
     #[test]
     fn mutate_path() -> anyhow::Result<()> {
-        let mut state = TestOpenApiFuzzerState::new();
-        let test_request = OpenApiRequest {
-            method: Method::Post,
-            path: "/simple".to_string(),
-            body: Body::Empty,
-            parameters: IndexMap::new(),
-        };
-        let mut input = OpenApiInput(vec![test_request]);
-        let mut mutator = DifferentPathMutator;
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let test_request = OpenApiRequest {
+                method: Method::Post,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
 
-        let result = mutator.mutate(&mut state, &mut input)?;
+            let mut input = OpenApiInput(vec![test_request]);
+            let mut mutator = DifferentPathMutator;
 
-        let expected_paths = ["/with-path-parameter/{id}", "/with-query-parameter"];
-        assert!(expected_paths.contains(&dbg!(input.0[0].path.as_str())));
-        assert_eq!(input.0[0].method, Method::Get);
-        assert_eq!(result, MutationResult::Mutated);
+            let result = mutator.mutate(&mut state, &mut input)?;
+
+            let expected_paths = ["/with-path-parameter/{id}", "/with-query-parameter"];
+            assert!(expected_paths.contains(&input.0[0].path.as_str()));
+            assert_eq!(input.0[0].method, Method::Get);
+            assert_eq!(result, MutationResult::Mutated);
+        }
 
         Ok(())
     }

--- a/src/openapi_mutator/different_path.rs
+++ b/src/openapi_mutator/different_path.rs
@@ -79,3 +79,39 @@ where
         Ok(MutationResult::Skipped)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use indexmap::IndexMap;
+    use libafl::mutators::{MutationResult, Mutator};
+
+    use crate::{
+        input::{Body, Method, OpenApiInput, OpenApiRequest},
+        state::tests::TestOpenApiFuzzerState,
+    };
+
+    use super::DifferentPathMutator;
+
+    /// Tests whether the mutator correctly changes the path of a request.
+    #[test]
+    fn mutate_path() -> anyhow::Result<()> {
+        let mut state = TestOpenApiFuzzerState::new();
+        let test_request = OpenApiRequest {
+            method: Method::Post,
+            path: "/simple".to_string(),
+            body: Body::Empty,
+            parameters: IndexMap::new(),
+        };
+        let mut input = OpenApiInput(vec![test_request]);
+        let mut mutator = DifferentPathMutator;
+
+        let result = mutator.mutate(&mut state, &mut input)?;
+
+        let expected_paths = ["/with-path-parameter/{id}", "/with-query-parameter"];
+        assert!(expected_paths.contains(&dbg!(input.0[0].path.as_str())));
+        assert_eq!(input.0[0].method, Method::Get);
+        assert_eq!(result, MutationResult::Mutated);
+
+        Ok(())
+    }
+}

--- a/src/openapi_mutator/different_path.rs
+++ b/src/openapi_mutator/different_path.rs
@@ -98,8 +98,8 @@ mod test {
         for _ in 0..100 {
             let mut state = TestOpenApiFuzzerState::new();
             let test_request = OpenApiRequest {
-                method: Method::Post,
-                path: "/simple".to_string(),
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
                 body: Body::Empty,
                 parameters: IndexMap::new(),
             };
@@ -109,9 +109,9 @@ mod test {
 
             let result = mutator.mutate(&mut state, &mut input)?;
 
-            let expected_paths = ["/with-path-parameter/{id}", "/with-query-parameter"];
-            assert!(expected_paths.contains(&input.0[0].path.as_str()));
-            assert_eq!(input.0[0].method, Method::Get);
+            let new_path = input.0[0].path.as_str();
+            assert!(new_path == "/with-path-parameter/{id}" || new_path == "/simple");
+            assert!(input.0[0].method == Method::Get || (new_path == "/simple" && input.0[0].method == Method::Delete));
             assert_eq!(result, MutationResult::Mutated);
         }
 

--- a/src/openapi_mutator/duplicate_request.rs
+++ b/src/openapi_mutator/duplicate_request.rs
@@ -69,9 +69,15 @@ where
 
 #[cfg(test)]
 mod test {
+    use indexmap::IndexMap;
     use libafl::mutators::{MutationResult, Mutator};
 
-    use crate::{input::OpenApiInput, state::tests::TestOpenApiFuzzerState};
+    use crate::{
+        input::{
+            parameter::ParameterKind, Body, Method, OpenApiInput, OpenApiRequest, ParameterContents,
+        },
+        state::tests::TestOpenApiFuzzerState,
+    };
 
     use super::DuplicateRequestMutator;
 
@@ -86,7 +92,80 @@ mod test {
             let result = mutator.mutate(&mut state, &mut input)?;
             assert_eq!(result, MutationResult::Skipped);
         }
-        
+
+        Ok(())
+    }
+
+    /// Tests whether the mutator correctly duplicates a "simple" request (i.e. no parameters or body).
+    #[test]
+    fn duplicate_request_simple() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let request = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![request]);
+            let mut mutator = DuplicateRequestMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+            assert_eq!(input.0[0].path, input.0[1].path);
+            assert_eq!(input.0[0].method, input.0[1].method);
+            assert_eq!(
+                input.0[0].body_content_type(),
+                input.0[1].body_content_type()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Tests whether the mutator correctly duplicates a request containing a parameter reference.
+    #[test]
+    fn duplicate_request_with_reference() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut parameters = IndexMap::new();
+            parameters.insert(
+                ("id".to_string(), ParameterKind::Query),
+                ParameterContents::Reference {
+                    request_index: 0,
+                    parameter_name: "id".to_string(),
+                },
+            );
+            let has_param = OpenApiRequest {
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
+                body: Body::Empty,
+                parameters,
+            };
+
+            let has_return_value = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![has_return_value, has_param]);
+            let mut mutator = DuplicateRequestMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+            let new_request = &mut input.0[2];
+            if new_request.path == "/with-query-parameter" {
+                let parameter = new_request
+                    .get_mut_parameter("id", ParameterKind::Query)
+                    .expect("Parameter was not correctly duplicated");
+                assert!(parameter.is_reference());
+                assert_eq!(parameter.reference_index().copied(), Some(0));
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/openapi_mutator/duplicate_request.rs
+++ b/src/openapi_mutator/duplicate_request.rs
@@ -66,3 +66,27 @@ where
         Ok(MutationResult::Mutated)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use libafl::mutators::{MutationResult, Mutator};
+
+    use crate::{input::OpenApiInput, state::tests::TestOpenApiFuzzerState};
+
+    use super::DuplicateRequestMutator;
+
+    /// Tests whether the mutator correctly skips mutation if there's no requests.
+    #[test]
+    fn skip_when_empty() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut input = OpenApiInput(vec![]);
+            let mut mutator = DuplicateRequestMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Skipped);
+        }
+        
+        Ok(())
+    }
+}

--- a/src/openapi_mutator/establish_link.rs
+++ b/src/openapi_mutator/establish_link.rs
@@ -50,7 +50,7 @@ where
         // Build a list of (x, y),
         // x is the request index for which the response contains a parameter y
         // y is the parameter name
-        let request_index_and_parameter_name_pairs = input.return_values(api);
+        let request_index_and_parameter_name_pairs = dbg!(input.return_values(api));
         if request_index_and_parameter_name_pairs.is_empty() {
             return Ok(MutationResult::Skipped);
         }
@@ -100,5 +100,108 @@ where
 
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use indexmap::IndexMap;
+    use libafl::mutators::{MutationResult, Mutator};
+
+    use crate::{
+        input::{parameter::ParameterKind, Body, Method, OpenApiInput, OpenApiRequest, ParameterContents},
+        state::tests::TestOpenApiFuzzerState,
+    };
+
+    use super::EstablishLinkMutator;
+
+    /// Tests whether the mutator correctly a link between an earlier request (to /simple) and a later parameter (id).
+    #[test]
+    fn establish_link() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut parameters = IndexMap::new();
+            parameters.insert(("id".to_string(), ParameterKind::Query), ParameterContents::Bytes(vec![0x0, 0x1, 0x2]));
+            let has_param = OpenApiRequest {
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
+                body: Body::Empty,
+                parameters,
+            };
+
+            let has_return_value = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![has_return_value, has_param]);
+            let mut mutator = EstablishLinkMutator;
+
+            
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+            let parameter = input.0[1].get_mut_parameter("id", ParameterKind::Query).expect("Request got the wrong parameter");
+            assert!(parameter.is_reference());
+            assert_eq!(parameter.reference_index().copied(), Some(0));
+        }
+
+        Ok(())
+    }
+
+    /// Tests whether the mutator correctly skips mutation in cases where no link can be established.
+    #[test]
+    fn skip_establish_link() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            // In this case, the mutator should skip mutation because the parameters are in the wrong order
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut parameters = IndexMap::new();
+            parameters.insert(("id".to_string(), ParameterKind::Query), ParameterContents::Bytes(vec![0x0, 0x1, 0x2]));
+            let has_param = OpenApiRequest {
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
+                body: Body::Empty,
+                parameters,
+            };
+
+            let has_return_value = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![has_param, has_return_value]);
+            let mut mutator = EstablishLinkMutator;
+
+            
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Skipped);
+
+            // In this case, the mutator should skip mutation because has_return_value has the wrong method
+            let mut state = TestOpenApiFuzzerState::new();
+            let has_param = OpenApiRequest {
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let has_return_value = OpenApiRequest {
+                method: Method::Delete,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![has_return_value, has_param]);
+            let mut mutator = EstablishLinkMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Skipped);
+        }
+
+        Ok(())
     }
 }

--- a/src/openapi_mutator/remove_request.rs
+++ b/src/openapi_mutator/remove_request.rs
@@ -83,42 +83,44 @@ mod test {
     /// Tests whether the mutator correctly removes a request from a list of 10 requests.
     #[test]
     fn remove_request() -> anyhow::Result<()> {
-        let mut state = TestOpenApiFuzzerState::new();
-        let test_request = OpenApiRequest {
-            method: Method::Get,
-            path: "/simple".to_string(),
-            body: Body::Empty,
-            parameters: IndexMap::new(),
-        };
-        let mut input = OpenApiInput(vec![test_request; 10]);
-        let mut mutator = RemoveRequestMutator;
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let test_request = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+            let mut input = OpenApiInput(vec![test_request; 10]);
+            let mut mutator = RemoveRequestMutator;
 
-        let result = mutator.mutate(&mut state, &mut input)?;
+            let result = mutator.mutate(&mut state, &mut input)?;
 
-        assert_eq!(input.0.len(), 9);
-        assert_eq!(result, MutationResult::Mutated);
-
+            assert_eq!(input.0.len(), 9);
+            assert_eq!(result, MutationResult::Mutated);
+        }
         Ok(())
     }
 
     /// Tests whether the mutator correctly keeps the request if it's the only one in the input.
     #[test]
     fn keep_single_request() -> anyhow::Result<()> {
-        let mut state = TestOpenApiFuzzerState::new();
-        let test_request = OpenApiRequest {
-            method: Method::Get,
-            path: "/simple".to_string(),
-            body: Body::Empty,
-            parameters: IndexMap::new(),
-        };
-        let mut input = OpenApiInput(vec![test_request]);
-        let mut mutator = RemoveRequestMutator;
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let test_request = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+            let mut input = OpenApiInput(vec![test_request]);
+            let mut mutator = RemoveRequestMutator;
 
-        let result = mutator.mutate(&mut state, &mut input)?;
+            let result = mutator.mutate(&mut state, &mut input)?;
 
-        assert_eq!(input.0.len(), 1);
-        assert_eq!(result, MutationResult::Skipped);
-
+            assert_eq!(input.0.len(), 1);
+            assert_eq!(result, MutationResult::Skipped);
+        }
         Ok(())
     }
 }

--- a/src/openapi_mutator/remove_request.rs
+++ b/src/openapi_mutator/remove_request.rs
@@ -67,3 +67,58 @@ where
         Ok(MutationResult::Mutated)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use indexmap::IndexMap;
+    use libafl::mutators::{MutationResult, Mutator};
+
+    use crate::{
+        input::{Body, Method, OpenApiInput, OpenApiRequest},
+        state::tests::TestOpenApiFuzzerState,
+    };
+
+    use super::RemoveRequestMutator;
+
+    /// Tests whether the mutator correctly removes a request from a list of 10 requests.
+    #[test]
+    fn remove_request() -> anyhow::Result<()> {
+        let mut state = TestOpenApiFuzzerState::new();
+        let test_request = OpenApiRequest {
+            method: Method::Get,
+            path: "/simple".to_string(),
+            body: Body::Empty,
+            parameters: IndexMap::new(),
+        };
+        let mut input = OpenApiInput(vec![test_request; 10]);
+        let mut mutator = RemoveRequestMutator;
+
+        let result = mutator.mutate(&mut state, &mut input)?;
+
+        assert_eq!(input.0.len(), 9);
+        assert_eq!(result, MutationResult::Mutated);
+
+        Ok(())
+    }
+
+    /// Tests whether the mutator correctly keeps the request if it's the only one in the input.
+    #[test]
+    fn keep_single_request() -> anyhow::Result<()> {
+        let mut state = TestOpenApiFuzzerState::new();
+        let test_request = OpenApiRequest {
+            method: Method::Get,
+            path: "/simple".to_string(),
+            body: Body::Empty,
+            parameters: IndexMap::new(),
+        };
+        let mut input = OpenApiInput(vec![test_request]);
+        let mut mutator = RemoveRequestMutator;
+
+        let result = mutator.mutate(&mut state, &mut input)?;
+
+        assert_eq!(input.0.len(), 1);
+        assert_eq!(result, MutationResult::Skipped);
+
+        Ok(())
+    }
+}

--- a/src/openapi_mutator/remove_request.rs
+++ b/src/openapi_mutator/remove_request.rs
@@ -74,7 +74,9 @@ mod test {
     use libafl::mutators::{MutationResult, Mutator};
 
     use crate::{
-        input::{Body, Method, OpenApiInput, OpenApiRequest},
+        input::{
+            parameter::ParameterKind, Body, Method, OpenApiInput, OpenApiRequest, ParameterContents,
+        },
         state::tests::TestOpenApiFuzzerState,
     };
 
@@ -120,6 +122,52 @@ mod test {
 
             assert_eq!(input.0.len(), 1);
             assert_eq!(result, MutationResult::Skipped);
+        }
+        Ok(())
+    }
+
+    /// Tests whether the mutator correctly fixes any references that may have changed due to the removal of a request.
+    #[test]
+    fn fix_references_when_removing() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut parameters = IndexMap::new();
+            parameters.insert(
+                ("id".to_string(), ParameterKind::Query),
+                ParameterContents::Reference {
+                    request_index: 1,
+                    parameter_name: "id".to_string(),
+                },
+            );
+            let has_param = OpenApiRequest {
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
+                body: Body::Empty,
+                parameters,
+            };
+
+            let has_return_value = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input =
+                OpenApiInput(vec![has_return_value.clone(), has_return_value, has_param]);
+            let mut mutator = RemoveRequestMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+
+            if input.0[1].path == "/with-query-parameter" {
+                // If the first simple request was removed, we would expect a reference_index of 0.
+                // But if the second simple request was removed, we would expect the parameter to have been changed to ParameterContents::Bytes.
+                let parameter = input.0[1]
+                    .get_mut_parameter("id", ParameterKind::Query)
+                    .expect("Could not find parameter after request removal");
+                assert!(parameter.reference_index().map_or(true, |&mut idx| idx == 0));
+            }
         }
         Ok(())
     }

--- a/src/openapi_mutator/swap_requests.rs
+++ b/src/openapi_mutator/swap_requests.rs
@@ -73,3 +73,88 @@ where
         Ok(MutationResult::Mutated)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use indexmap::IndexMap;
+    use libafl::mutators::{MutationResult, Mutator};
+
+    use crate::{
+        input::{
+            parameter::ParameterKind, Body, Method, OpenApiInput, OpenApiRequest, ParameterContents,
+        },
+        state::tests::TestOpenApiFuzzerState,
+    };
+
+    use super::SwapRequestsMutator;
+
+    /// Tests whether the mutator correctly swaps two simple requests.
+    #[test]
+    fn swap_simple_requests() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let test_request_1 = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+            let test_request_2 = OpenApiRequest {
+                method: Method::Delete,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![test_request_1, test_request_2]);
+            let mut mutator = SwapRequestsMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+            assert_eq!(input.0[0].method, Method::Delete);
+            assert_eq!(input.0[1].method, Method::Get);
+        }
+        Ok(())
+    }
+
+    /// Tests whether the mutator correctly breaks any references when swapping requests.
+    #[test]
+    fn remove_references_when_swapping() -> anyhow::Result<()> {
+        for _ in 0..100 {
+            let mut state = TestOpenApiFuzzerState::new();
+            let mut parameters = IndexMap::new();
+            parameters.insert(
+                ("id".to_string(), ParameterKind::Query),
+                ParameterContents::Reference {
+                    request_index: 1,
+                    parameter_name: "id".to_string(),
+                },
+            );
+            let has_param = OpenApiRequest {
+                method: Method::Get,
+                path: "/with-query-parameter".to_string(),
+                body: Body::Empty,
+                parameters,
+            };
+
+            let has_return_value = OpenApiRequest {
+                method: Method::Get,
+                path: "/simple".to_string(),
+                body: Body::Empty,
+                parameters: IndexMap::new(),
+            };
+
+            let mut input = OpenApiInput(vec![has_return_value, has_param]);
+            let mut mutator = SwapRequestsMutator;
+
+            let result = mutator.mutate(&mut state, &mut input)?;
+            assert_eq!(result, MutationResult::Mutated);
+            assert!(input.0[0]
+                .get_mut_parameter("id", ParameterKind::Query)
+                .expect("Could not find parameter after request removal")
+                .bytes()
+                .is_some());
+        }
+        Ok(())
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -384,6 +384,7 @@ where
 
 #[cfg(test)]
 pub mod tests {
+    use libafl::state::HasRand;
     use libafl_bolts::rands::StdRand;
     use openapiv3::OpenAPI;
     use super::HasRandAndOpenAPI;
@@ -452,6 +453,18 @@ pub mod tests {
 
         fn rand_mut_and_openapi(&mut self) -> (&mut Self::Rand, &openapiv3::OpenAPI) {
             (&mut self.rand, &self.openapi)
+        }
+    }
+
+    impl HasRand for TestOpenApiFuzzerState {
+        type Rand = StdRand;
+
+        fn rand(&self) -> &Self::Rand {
+            &self.rand
+        }
+
+        fn rand_mut(&mut self) -> &mut Self::Rand {
+            &mut self.rand
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -395,6 +395,9 @@ pub mod tests {
     }
 
     impl TestOpenApiFuzzerState {
+        /// The paths that occur in the spec provided by this test state.
+        pub const PATHS: [&'static str; 3] = ["/simple", "/with-path-parameter/{id}", "/with-query-parameter"];
+
         pub fn new() -> Self {
             const DUMMY_SPEC: &'static str = r#"
             openapi: 3.0.4
@@ -409,6 +412,14 @@ pub mod tests {
                         responses:
                             "200":
                                 description: OK
+                                content:
+                                    application/json:
+                                        schema:
+                                            type: object
+                                            properties:
+                                                id:
+                                                    type: integer
+                                                    description: The user ID.
                     delete:
                         responses:
                             "200":
@@ -418,14 +429,6 @@ pub mod tests {
                         responses:
                             "200":
                                 description: OK
-                                content:
-                                    application/json:
-                                        schema:
-                                            type: object
-                                            properties:
-                                                id:
-                                                    type: integer
-                                                    description: The user ID.
                         parameters:
                             - name: id
                               in: path

--- a/src/state.rs
+++ b/src/state.rs
@@ -418,6 +418,14 @@ pub mod tests {
                         responses:
                             "200":
                                 description: OK
+                                content:
+                                    application/json:
+                                        schema:
+                                            type: object
+                                            properties:
+                                                id:
+                                                    type: integer
+                                                    description: The user ID.
                         parameters:
                             - name: id
                               in: path


### PR DESCRIPTION
Adds tests for all mutators (except `StringInterestingMutator`, because there is not much to test there).

Because the mutators all involve random state and we want to make sure that the different code paths are all tested, they are all run in a loop of 100 iterators (with a new random state each iteration). This should catch any bugs occurring only on certain code paths fairly quickly.

The tests found one small issue in `DifferrentMethodMutator`, where it could sometimes replace a method with that same method. This pull request also fixes that issue.