### PR TITLE
Upgrade libafl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Highlights
 
 ## Features
+- Updated [LibAFL](https://github.com/AFLplusplus/LibAFL) to 0.15.3 in
+  [#107](https://github.com/TNO-S3/WuppieFuzz/pull/107)
 
 ## Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,21 +275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "castaway"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,20 +371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +379,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.59.0",
 ]
 
@@ -484,31 +455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "csv"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,41 +499,6 @@ checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
  "nix 0.30.1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -739,9 +650,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastbloom"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
+checksum = "dee0191af12b622a9263467105cda1a21f8e6cbc535b2fd49de829ca92794e32"
 dependencies = [
  "getrandom 0.3.3",
  "siphasher",
@@ -862,7 +773,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1189,12 +1100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,27 +1140,8 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
-name = "instability"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
-dependencies = [
- "darling",
- "indoc",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1402,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "libafl"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9794a343d5fa693c28cd23af59043212d70036fb5ebc0afa179b625f95f4078e"
+checksum = "07dd8d2c0eadc478a759f6d3862eec49a6818a0316b415bb0d2638146b021738"
 dependencies = [
  "ahash",
  "arbitrary-int",
@@ -1414,7 +1300,6 @@ dependencies = [
  "clap",
  "const_format",
  "const_panic",
- "crossterm",
  "fastbloom",
  "fs2",
  "hashbrown 0.14.5",
@@ -1427,7 +1312,6 @@ dependencies = [
  "nix 0.29.0",
  "num-traits",
  "postcard",
- "ratatui",
  "regex",
  "rustversion",
  "serde",
@@ -1443,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "libafl_bolts"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e69630477e025040c68537d88c7263a8f00c5d7ba3eae1d3cf0d992ecc1d1e"
+checksum = "35162166ed6c0193089e6c23de536ef66c1644d987c1e590a581bd47f7988bb6"
 dependencies = [
  "ahash",
  "backtrace",
@@ -1454,9 +1338,10 @@ dependencies = [
  "hashbrown 0.14.5",
  "hostname",
  "libafl_derive",
+ "libafl_wide",
  "libc",
  "log",
- "mach",
+ "mach2",
  "miniz_oxide",
  "nix 0.29.0",
  "num_enum",
@@ -1489,6 +1374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libafl_wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f28d525f6e361b6cd55c0da5347027860a902d638d15194c16dc2f39a5ba9f"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,12 +1405,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1556,19 +1445,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.12.5"
+name = "mach2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.4",
-]
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
@@ -1620,7 +1500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -1884,12 +1763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,27 +1938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags",
- "cassowary",
- "compact_str",
- "crossterm",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru",
- "paste",
- "strum",
- "unicode-segmentation",
- "unicode-truncate 1.1.0",
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,19 +2067,6 @@ checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -2235,7 +2074,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -2461,36 +2300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,28 +2353,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "subtle"
@@ -2634,7 +2421,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2935,31 +2722,14 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-truncate"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3557,7 +3327,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "tempfile",
- "unicode-truncate 2.0.0",
+ "unicode-truncate",
  "url",
  "urlencoding",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -401,15 +401,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.0"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width 0.2.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -531,13 +531,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5"
 dependencies = [
- "quote",
- "syn",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "ctrlc"
@@ -612,6 +618,21 @@ checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "either"
@@ -718,11 +739,11 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastbloom"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b679f25009b51b71506296f95fb6362ba7d0151172fa7373a8d1611b8bc5d10f"
+checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "siphasher",
  "wide",
 ]
@@ -773,6 +794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1197,14 +1228,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
+ "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.0",
- "unit-prefix",
  "web-time",
 ]
 
@@ -1225,6 +1256,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1360,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "libafl"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bfea5b57dd448190cc1822bc538222e9e74fa5b4824213b0bdf116a87edc69"
+checksum = "9794a343d5fa693c28cd23af59043212d70036fb5ebc0afa179b625f95f4078e"
 dependencies = [
  "ahash",
  "arbitrary-int",
@@ -1374,6 +1416,7 @@ dependencies = [
  "const_panic",
  "crossterm",
  "fastbloom",
+ "fs2",
  "hashbrown 0.14.5",
  "libafl_bolts",
  "libafl_derive",
@@ -1394,14 +1437,15 @@ dependencies = [
  "typed-builder",
  "uuid",
  "wait-timeout",
+ "winapi",
  "windows",
 ]
 
 [[package]]
 name = "libafl_bolts"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861b93e34c52a9c72209cbd104165482cc4def054525aadceb4ae0a9c571e3bd"
+checksum = "51e69630477e025040c68537d88c7263a8f00c5d7ba3eae1d3cf0d992ecc1d1e"
 dependencies = [
  "ahash",
  "backtrace",
@@ -1416,15 +1460,18 @@ dependencies = [
  "miniz_oxide",
  "nix 0.29.0",
  "num_enum",
+ "once_cell",
  "postcard",
- "rand_core 0.6.4",
+ "rand_core",
  "rustversion",
  "serde",
  "serial_test",
  "static_assertions",
  "tuple_list",
+ "typeid",
  "uds",
  "uuid",
+ "winapi",
  "windows",
  "windows-result",
  "xxhash-rust",
@@ -1720,6 +1767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,9 +1840,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.5.1+3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
 dependencies = [
  "cc",
 ]
@@ -1979,7 +2032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1989,14 +2042,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2078,9 +2125,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.21"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8cea6b35bcceb099f30173754403d2eba0a5dc18cea3630fccd88251909288"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
@@ -2674,15 +2721,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "windows-sys 0.52.0",
 ]
@@ -2839,18 +2888,18 @@ checksum = "141fb9f71ee586d956d7d6e4d5a9ef8e946061188520140f7591b668841d502e"
 
 [[package]]
 name = "typed-builder"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
+checksum = "ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+checksum = "60d8d828da2a3d759d3519cdf29a5bac49c77d039ad36d0782edadbf9cd5415b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2923,12 +2972,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,15 +53,15 @@ cookie = "0.18.1"
 cookie_store = "0.21.1"
 ctrlc = "3.4.7"
 env_logger = "0.11.8"
-indexmap = { version = "2.9.0", features = ["serde"] }
+indexmap = { version = "2.9.0", features = ["std", "serde"] }
 indicatif = "0.17.11"
 iter-read = "1.0.1"
 itertools = "0.14.0"
 json_env_logger2 = "0.2.1"
 lazy_static = "1.4.0"
 lcov = "0.8"
-libafl = { version = "=0.15.0", features = ["clap"] }
-libafl_bolts = { version = "=0.15.0", features = ["prelude"] }
+libafl = { version = "=0.15.2", features = ["clap"] }
+libafl_bolts = { version = "=0.15.2", features = ["prelude"] }
 log = { version = "0.4.27", features = ["serde"] }
 num = { version = "0.4.2", default-features = false }
 num-derive = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,15 +53,15 @@ cookie = "0.18.1"
 cookie_store = "0.21.1"
 ctrlc = "3.4.7"
 env_logger = "0.11.8"
-indexmap = { version = "2.9.0", features = ["std", "serde"] }
+indexmap = { version = "2.9.0", features = ["serde"] }
 indicatif = "0.17.11"
 iter-read = "1.0.1"
 itertools = "0.14.0"
 json_env_logger2 = "0.2.1"
 lazy_static = "1.4.0"
 lcov = "0.8"
-libafl = { version = "=0.15.2", features = ["clap"] }
-libafl_bolts = { version = "=0.15.2", features = ["prelude"] }
+libafl = { version = "=0.15.3", features = ["clap"] }
+libafl_bolts = { version = "=0.15.3", features = ["prelude"] }
 log = { version = "0.4.27", features = ["serde"] }
 num = { version = "0.4.2", default-features = false }
 num-derive = "0.4.2"

--- a/SBOM.txt
+++ b/SBOM.txt
@@ -73,12 +73,6 @@ byteorder 1.5.0
 bytes 1.10.1
 	licensed under "MIT"
 	by Carl Lerche <me@carllerche.com>|Sean McArthur <sean@seanmonstar.com>
-cassowary 0.3.0
-	licensed under "Apache-2.0 OR MIT"
-	by Dylan Ede <dylanede@googlemail.com>
-castaway 0.2.3
-	licensed under "MIT"
-	by Stephen M. Coakley <me@stephencoakley.com>
 cesu8 1.1.0
 	licensed under "Apache-2.0 OR MIT"
 	by Eric Kidd <git@randomhacks.net>
@@ -106,9 +100,6 @@ cobs 0.3.0
 colorchoice 1.0.4
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
-compact_str 0.8.1
-	licensed under "MIT"
-	by Parker Timmerman <parker@parkertimmerman.com>
 console 0.15.11
 	licensed under "MIT"
 	by Armin Ronacher <armin.ronacher@active-4.com>
@@ -133,12 +124,6 @@ core-foundation 0.9.4
 core-foundation-sys 0.8.7
 	licensed under "Apache-2.0 OR MIT"
 	by The Servo Project Developers
-crossterm 0.28.1
-	licensed under "MIT"
-	by T. Post
-crossterm_winapi 0.9.1
-	licensed under "MIT"
-	by T. Post
 ctor 0.4.2
 	licensed under "Apache-2.0 OR MIT"
 	by Matt Mastracci <matthew@mastracci.com>
@@ -148,15 +133,6 @@ ctor-proc-macro 0.0.5
 ctrlc 3.4.7
 	licensed under "Apache-2.0 OR MIT"
 	by Antti Keränen <detegr@gmail.com>
-darling 0.20.11
-	licensed under "MIT"
-	by Ted Driggs <ted.driggs@outlook.com>
-darling_core 0.20.11
-	licensed under "MIT"
-	by Ted Driggs <ted.driggs@outlook.com>
-darling_macro 0.20.11
-	licensed under "MIT"
-	by Ted Driggs <ted.driggs@outlook.com>
 deranged 0.4.0
 	licensed under "Apache-2.0 OR MIT"
 	by Jacob Pratt <jacob@jhpratt.dev>
@@ -211,7 +187,7 @@ fallible-iterator 0.3.0
 fallible-streaming-iterator 0.1.9
 	licensed under "Apache-2.0 OR MIT"
 	by Steven Fackler <sfackler@gmail.com>
-fastbloom 0.9.0
+fastbloom 0.11.0
 	licensed under "Apache-2.0 OR MIT"
 	by tomtomwombat
 fastrand 2.3.0
@@ -334,9 +310,6 @@ icu_properties_data 2.0.1
 icu_provider 2.0.0
 	licensed under "Unicode-3.0"
 	by The ICU4X Project Developers
-ident_case 1.0.1
-	licensed under "Apache-2.0 OR MIT"
-	by Ted Driggs <ted.driggs@outlook.com>
 idna 1.0.3
 	licensed under "Apache-2.0 OR MIT"
 	by The rust-url developers
@@ -349,12 +322,6 @@ indexmap 2.10.0
 indicatif 0.17.11
 	licensed under "MIT"
 	by unspecified authors
-indoc 2.0.6
-	licensed under "Apache-2.0 OR MIT"
-	by David Tolnay <dtolnay@gmail.com>
-instability 0.3.7
-	licensed under "MIT"
-	by Stephen M. Coakley <me@stephencoakley.com>|The Ratatui Developers
 io-uring 0.7.8
 	licensed under "Apache-2.0 OR MIT"
 	by quininer <quininer@live.com>
@@ -400,15 +367,18 @@ lazy_static 1.5.0
 lcov 0.8.1
 	licensed under "Apache-2.0 OR MIT"
 	by gifnksm <makoto.nksm+github@gmail.com>
-libafl 0.15.2
+libafl 0.15.3
 	licensed under "Apache-2.0 OR MIT"
 	by Andrea Fioraldi <andreafioraldi@gmail.com>|Dominik Maier <domenukk@gmail.com>
-libafl_bolts 0.15.2
+libafl_bolts 0.15.3
 	licensed under "Apache-2.0 OR MIT"
 	by Andrea Fioraldi <andreafioraldi@gmail.com>|Dominik Maier <domenukk@gmail.com>
 libafl_derive 0.15.3
 	licensed under "Apache-2.0 OR MIT"
 	by Andrea Fioraldi <andreafioraldi@gmail.com>
+libafl_wide 0.7.33
+	licensed under "Apache-2.0 OR MIT OR Zlib"
+	by Lokathor <zefria@gmail.com>
 libc 0.2.174
 	licensed under "Apache-2.0 OR MIT"
 	by The Rust Project Developers
@@ -418,9 +388,6 @@ libm 0.2.15
 libsqlite3-sys 0.33.0
 	licensed under "MIT"
 	by The rusqlite developers
-linux-raw-sys 0.4.15
-	licensed under "Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT"
-	by Dan Gohman <dev@sunfishcode.online>
 linux-raw-sys 0.9.4
 	licensed under "Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT"
 	by Dan Gohman <dev@sunfishcode.online>
@@ -436,12 +403,9 @@ lock_api 0.4.13
 log 0.4.27
 	licensed under "Apache-2.0 OR MIT"
 	by The Rust Project Developers
-lru 0.12.5
-	licensed under "MIT"
-	by Jerome Froelich <jeromefroelic@hotmail.com>
-mach 0.3.2
-	licensed under "BSD-2-Clause"
-	by Nick Fitzgerald <fitzgen@gmail.com>|David Cuddeback <david.cuddeback@gmail.com>|Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>
+mach2 0.4.3
+	licensed under "Apache-2.0 OR BSD-2-Clause OR MIT"
+	by unspecified authors
 memchr 2.7.5
 	licensed under "MIT OR Unlicense"
 	by Andrew Gallant <jamslam@gmail.com>|bluss
@@ -532,9 +496,6 @@ parking_lot 0.12.4
 parking_lot_core 0.9.11
 	licensed under "Apache-2.0 OR MIT"
 	by Amanieu d'Antras <amanieu@gmail.com>
-paste 1.0.15
-	licensed under "Apache-2.0 OR MIT"
-	by David Tolnay <dtolnay@gmail.com>
 percent-encoding 2.3.1
 	licensed under "Apache-2.0 OR MIT"
 	by The rust-url developers
@@ -595,9 +556,6 @@ rand_core 0.9.3
 rand_regex 0.18.1
 	licensed under "MIT"
 	by kennytm <kennytm@gmail.com>
-ratatui 0.29.0
-	licensed under "MIT"
-	by Florian Dehau <work@fdehau.com>|The Ratatui Developers
 redox_syscall 0.5.13
 	licensed under "MIT"
 	by Jeremy Soller <jackpot51@gmail.com>
@@ -625,9 +583,6 @@ rusqlite 0.35.0
 rustc-demangle 0.1.25
 	licensed under "Apache-2.0 OR MIT"
 	by Alex Crichton <alex@alexcrichton.com>
-rustix 0.38.44
-	licensed under "Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT"
-	by Dan Gohman <dev@sunfishcode.online>|Jakub Konka <kubkon@jakubkonka.com>
 rustix 1.0.7
 	licensed under "Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT"
 	by Dan Gohman <dev@sunfishcode.online>|Jakub Konka <kubkon@jakubkonka.com>
@@ -691,15 +646,6 @@ serial_test 3.2.0
 serial_test_derive 3.2.0
 	licensed under "MIT"
 	by Tom Parker-Shemilt <palfrey@tevp.net>
-signal-hook 0.3.18
-	licensed under "Apache-2.0 OR MIT"
-	by Michal 'vorner' Vaner <vorner@vorner.cz>|Thomas Himmelstoss <thimm@posteo.de>
-signal-hook-mio 0.2.4
-	licensed under "Apache-2.0 OR MIT"
-	by Michal 'vorner' Vaner <vorner@vorner.cz>|Thomas Himmelstoss <thimm@posteo.de>
-signal-hook-registry 1.4.5
-	licensed under "Apache-2.0 OR MIT"
-	by Michal 'vorner' Vaner <vorner@vorner.cz>|Masaki Hara <ackie.h.gmai@gmail.com>
 siphasher 1.0.1
 	licensed under "Apache-2.0 OR MIT"
 	by Frank Denis <github@pureftpd.org>
@@ -721,12 +667,6 @@ static_assertions 1.1.0
 strsim 0.11.1
 	licensed under "MIT"
 	by Danny Guo <danny@dannyguo.com>|maxbachmann <oss@maxbachmann.de>
-strum 0.26.3
-	licensed under "MIT"
-	by Peter Glotfelty <peter.glotfelty@microsoft.com>
-strum_macros 0.26.4
-	licensed under "MIT"
-	by Peter Glotfelty <peter.glotfelty@microsoft.com>
 subtle 2.6.1
 	licensed under "BSD-3-Clause"
 	by Isis Lovecruft <isis@patternsinthevoid.net>|Henry de Valence <hdevalence@hdevalence.ca>
@@ -826,15 +766,9 @@ unicode-ident 1.0.18
 unicode-segmentation 1.12.0
 	licensed under "Apache-2.0 OR MIT"
 	by kwantam <kwantam@gmail.com>|Manish Goregaokar <manishsmail@gmail.com>
-unicode-truncate 1.1.0
-	licensed under "Apache-2.0 OR MIT"
-	by Aetf <aetf@unlimitedcodeworks.xyz>
 unicode-truncate 2.0.0
 	licensed under "Apache-2.0 OR MIT"
 	by Aetf <aetf@unlimitedcodeworks.xyz>
-unicode-width 0.1.14
-	licensed under "Apache-2.0 OR MIT"
-	by kwantam <kwantam@gmail.com>|Manish Goregaokar <manishsmail@gmail.com>
 unicode-width 0.2.0
 	licensed under "Apache-2.0 OR MIT"
 	by kwantam <kwantam@gmail.com>|Manish Goregaokar <manishsmail@gmail.com>

--- a/SBOM.txt
+++ b/SBOM.txt
@@ -109,9 +109,9 @@ colorchoice 1.0.4
 compact_str 0.8.1
 	licensed under "MIT"
 	by Parker Timmerman <parker@parkertimmerman.com>
-console 0.16.0
+console 0.15.11
 	licensed under "MIT"
-	by unspecified authors
+	by Armin Ronacher <armin.ronacher@active-4.com>
 const_format 0.2.34
 	licensed under "Zlib"
 	by rodrimati1992 <rodrimatt1985@gmail.com>
@@ -139,7 +139,10 @@ crossterm 0.28.1
 crossterm_winapi 0.9.1
 	licensed under "MIT"
 	by T. Post
-ctor 0.2.9
+ctor 0.4.2
+	licensed under "Apache-2.0 OR MIT"
+	by Matt Mastracci <matthew@mastracci.com>
+ctor-proc-macro 0.0.5
 	licensed under "Apache-2.0 OR MIT"
 	by Matt Mastracci <matthew@mastracci.com>
 ctrlc 3.4.7
@@ -163,6 +166,12 @@ displaydoc 0.2.5
 document-features 0.2.11
 	licensed under "Apache-2.0 OR MIT"
 	by Slint Developers <info@slint.dev>
+dtor 0.0.6
+	licensed under "Apache-2.0 OR MIT"
+	by Matt Mastracci <matthew@mastracci.com>
+dtor-proc-macro 0.0.5
+	licensed under "Apache-2.0 OR MIT"
+	by Matt Mastracci <matthew@mastracci.com>
 either 1.15.0
 	licensed under "Apache-2.0 OR MIT"
 	by bluss
@@ -202,7 +211,7 @@ fallible-iterator 0.3.0
 fallible-streaming-iterator 0.1.9
 	licensed under "Apache-2.0 OR MIT"
 	by Steven Fackler <sfackler@gmail.com>
-fastbloom 0.8.0
+fastbloom 0.9.0
 	licensed under "Apache-2.0 OR MIT"
 	by tomtomwombat
 fastrand 2.3.0
@@ -226,6 +235,9 @@ foreign-types-shared 0.1.1
 form_urlencoded 1.2.1
 	licensed under "Apache-2.0 OR MIT"
 	by The rust-url developers
+fs2 0.4.3
+	licensed under "Apache-2.0 OR MIT"
+	by Dan Burkert <dan@danburkert.com>
 futures-channel 0.3.31
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
@@ -334,7 +346,7 @@ idna_adapter 1.2.1
 indexmap 2.10.0
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
-indicatif 0.17.12
+indicatif 0.17.11
 	licensed under "MIT"
 	by unspecified authors
 indoc 2.0.6
@@ -343,6 +355,9 @@ indoc 2.0.6
 instability 0.3.7
 	licensed under "MIT"
 	by Stephen M. Coakley <me@stephencoakley.com>|The Ratatui Developers
+io-uring 0.7.8
+	licensed under "Apache-2.0 OR MIT"
+	by quininer <quininer@live.com>
 ipnet 2.11.0
 	licensed under "Apache-2.0 OR MIT"
 	by Kris Price <kris@krisprice.nz>
@@ -385,10 +400,10 @@ lazy_static 1.5.0
 lcov 0.8.1
 	licensed under "Apache-2.0 OR MIT"
 	by gifnksm <makoto.nksm+github@gmail.com>
-libafl 0.15.0
+libafl 0.15.2
 	licensed under "Apache-2.0 OR MIT"
 	by Andrea Fioraldi <andreafioraldi@gmail.com>|Dominik Maier <domenukk@gmail.com>
-libafl_bolts 0.15.0
+libafl_bolts 0.15.2
 	licensed under "Apache-2.0 OR MIT"
 	by Andrea Fioraldi <andreafioraldi@gmail.com>|Dominik Maier <domenukk@gmail.com>
 libafl_derive 0.15.3
@@ -484,6 +499,9 @@ num_enum 0.7.4
 num_enum_derive 0.7.4
 	licensed under "Apache-2.0 OR BSD-3-Clause OR MIT"
 	by Daniel Wagner-Hall <dawagner@gmail.com>|Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>|Vincent Esche <regexident@gmail.com>
+number_prefix 0.4.0
+	licensed under "MIT"
+	by Benjamin Sago <ogham@bsago.me>
 object 0.36.7
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
@@ -571,9 +589,6 @@ rand 0.9.1
 rand_chacha 0.9.0
 	licensed under "Apache-2.0 OR MIT"
 	by The Rand Project Developers|The Rust Project Developers|The CryptoCorrosion Contributors
-rand_core 0.6.4
-	licensed under "Apache-2.0 OR MIT"
-	by The Rand Project Developers|The Rust Project Developers
 rand_core 0.9.3
 	licensed under "Apache-2.0 OR MIT"
 	by The Rand Project Developers|The Rust Project Developers
@@ -595,7 +610,7 @@ regex-automata 0.4.9
 regex-syntax 0.8.5
 	licensed under "Apache-2.0 OR MIT"
 	by The Rust Project Developers|Andrew Gallant <jamslam@gmail.com>
-reqwest 0.12.21
+reqwest 0.12.22
 	licensed under "Apache-2.0 OR MIT"
 	by Sean McArthur <sean@seanmonstar.com>
 reqwest_cookie_store 0.8.0
@@ -757,7 +772,7 @@ time-macros 0.2.22
 tinystr 0.8.1
 	licensed under "Unicode-3.0"
 	by The ICU4X Project Developers
-tokio 1.45.1
+tokio 1.46.1
 	licensed under "MIT"
 	by Tokio Contributors <team@tokio.rs>
 tokio-native-tls 0.3.1
@@ -793,10 +808,10 @@ try-lock 0.2.5
 tuple_list 0.1.3
 	licensed under "MIT"
 	by Valerii Lashmanov <vflashm@gmail.com>
-typed-builder 0.20.1
+typed-builder 0.21.0
 	licensed under "Apache-2.0 OR MIT"
 	by IdanArye <idanarye@gmail.com>|Chris Morgan <me@chrismorgan.info>
-typed-builder-macro 0.20.1
+typed-builder-macro 0.21.0
 	licensed under "Apache-2.0 OR MIT"
 	by IdanArye <idanarye@gmail.com>|Chris Morgan <me@chrismorgan.info>
 typeid 1.0.3
@@ -826,9 +841,6 @@ unicode-width 0.2.0
 unicode-xid 0.2.6
 	licensed under "Apache-2.0 OR MIT"
 	by erick.tryzelaar <erick.tryzelaar@gmail.com>|kwantam <kwantam@gmail.com>|Manish Goregaokar <manishsmail@gmail.com>
-unit-prefix 0.5.1
-	licensed under "MIT"
-	by Fabio Valentini <decathorpe@gmail.com>|Benjamin Sago <ogham@bsago.me>
 unsafe-libyaml 0.2.11
 	licensed under "MIT"
 	by David Tolnay <dtolnay@gmail.com>

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -237,7 +237,7 @@ where
         event_manager: &mut EM,
     ) -> Result<(), Error>
     where
-        EM: EventFirer<OpenApiInput, FuzzerState> + SendExiting, // + EventProcessor<EM, FuzzerState, FZ>,
+        EM: EventFirer<OpenApiInput, FuzzerState> + SendExiting,
     {
         if state.stop_requested() {
             state.discard_stop_request();
@@ -331,7 +331,6 @@ where
 impl<EM, FZ, OT> Executor<EM, OpenApiInput, FuzzerState, FZ> for SequenceExecutor<'_, OT>
 where
     EM: EventFirer<OpenApiInput, FuzzerState> + EventRestarter<FuzzerState> + SendExiting,
-    // + EventProcessor<EM, FuzzerState, FZ>,
     OT: ObserversTuple<OpenApiInput, FuzzerState>,
 {
     fn run_target(

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,9 +13,9 @@ use std::{
 
 use libafl::{
     Error,
-    events::{Event, EventFirer, EventProcessor, EventRestarter},
+    events::{Event, EventFirer, EventRestarter, SendExiting},
     executors::{Executor, ExitKind, HasObservers},
-    monitors::{AggregatorOps, UserStats, UserStatsValue},
+    monitors::stats::{AggregatorOps, UserStats, UserStatsValue},
     observers::ObserversTuple,
     state::{HasExecutions, Stoppable},
 };
@@ -230,14 +230,14 @@ where
         (exit_kind, performed_requests)
     }
 
-    fn pre_exec<EM, FZ>(
+    fn pre_exec<EM>(
         &mut self,
         state: &mut FuzzerState,
         _input: &OpenApiInput,
         event_manager: &mut EM,
     ) -> Result<(), Error>
     where
-        EM: EventFirer<OpenApiInput, FuzzerState> + EventProcessor<EM, FuzzerState, FZ>,
+        EM: EventFirer<OpenApiInput, FuzzerState> + SendExiting, // + EventProcessor<EM, FuzzerState, FZ>,
     {
         if state.stop_requested() {
             state.discard_stop_request();
@@ -322,9 +322,8 @@ where
 
 impl<EM, FZ, OT> Executor<EM, OpenApiInput, FuzzerState, FZ> for SequenceExecutor<'_, OT>
 where
-    EM: EventFirer<OpenApiInput, FuzzerState>
-        + EventRestarter<FuzzerState>
-        + EventProcessor<EM, FuzzerState, FZ>,
+    EM: EventFirer<OpenApiInput, FuzzerState> + EventRestarter<FuzzerState> + SendExiting,
+    // + EventProcessor<EM, FuzzerState, FZ>,
     OT: ObserversTuple<OpenApiInput, FuzzerState>,
 {
     fn run_target(

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -189,12 +189,14 @@ pub fn fuzz() -> Result<()> {
         let input = initial_corpus_cloned
             .cloned_input_for_id(input_id)
             .expect("Failed to load input");
-        executor.run_target(&mut fuzzer, &mut state, &mut mgr, &input)?;
+        let exit_kind = executor.run_target(&mut fuzzer, &mut state, &mut mgr, &input)?;
+        let exec_input_result = ExecuteInputResult::new(true, false);
         fuzzer.process_execution(
             &mut state,
             &mut mgr,
             &input,
-            &ExecuteInputResult::None,
+            &exec_input_result,
+            &exit_kind,
             executor.observers_mut().deref_mut(),
         )?;
     }

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -2,7 +2,6 @@
 use std::ptr::write_volatile;
 use std::{
     fs::create_dir_all,
-    marker::PhantomData,
     ops::DerefMut,
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -14,15 +13,12 @@ use libafl::Fuzzer; // This may be marked unused, but will make the compiler giv
 use libafl::{
     ExecuteInputResult, ExecutionProcessor, HasNamedMetadata,
     corpus::{Corpus, OnDiskCorpus},
-    events::{Event, EventFirer, SimpleEventManager},
+    events::{Event, EventFirer, EventWithStats, ExecStats, SimpleEventManager},
     executors::{Executor, ExitKind, HasObservers},
     feedback_or,
-    feedbacks::{
-        CrashFeedback, DifferentIsNovel, Feedback, MapFeedback, MaxMapFeedback, MaxReducer,
-        TimeFeedback,
-    },
+    feedbacks::{CrashFeedback, Feedback, MaxMapFeedback, TimeFeedback, simd::SimdMapFeedback},
     fuzzer::StdFuzzer,
-    mutators::StdScheduledMutator,
+    mutators::HavocScheduledMutator,
     observers::{CanTrack, ExplicitTracking, MultiMapObserver, StdMapObserver, TimeObserver},
     schedulers::{
         IndexesLenTimeMinimizerScheduler, PowerQueueScheduler, powersched::PowerSchedule,
@@ -34,6 +30,7 @@ use libafl_bolts::{
     current_nanos, current_time,
     prelude::OwnedMutSlice,
     rands::StdRand,
+    simd::{SimdMaxReducer, vector::u8x16},
     tuples::{MatchName, tuple_list},
 };
 use log::{error, info};
@@ -151,7 +148,7 @@ pub fn fuzz() -> Result<()> {
         time_observer
     );
 
-    let mutator_openapi = StdScheduledMutator::new(havoc_mutations_openapi());
+    let mutator_openapi = HavocScheduledMutator::new(havoc_mutations_openapi());
 
     // The order of the stages matter!
     let power = StdPowerMutationalStage::new(mutator_openapi);
@@ -170,15 +167,17 @@ pub fn fuzz() -> Result<()> {
     let corpus_size = state.corpus().count();
     if let Err(e) = mgr.fire(
         &mut state,
-        Event::NewTestcase {
-            input: OpenApiInput(vec![]),
-            observers_buf: None,
-            exit_kind: ExitKind::Ok,
-            corpus_size,
-            client_config: mgr.configuration(),
-            time: current_time(),
-            forward_id: None,
-        },
+        EventWithStats::new(
+            Event::NewTestcase {
+                input: OpenApiInput(vec![]),
+                observers_buf: None,
+                exit_kind: ExitKind::Ok,
+                corpus_size,
+                client_config: mgr.configuration(),
+                forward_id: None,
+            },
+            ExecStats::new(current_time(), 0),
+        ),
     ) {
         error!("Err: failed to fire event{e:?}")
     }
@@ -217,11 +216,7 @@ pub fn fuzz() -> Result<()> {
         let executions = *state.executions();
         if let Err(e) = mgr.fire(
             &mut state,
-            Event::UpdateExecStats {
-                time: current_time(),
-                executions,
-                phantom: PhantomData,
-            },
+            EventWithStats::new(Event::Heartbeat, ExecStats::new(current_time(), executions)),
         ) {
             error!("Err: failed to fire event{e:?}")
         }
@@ -237,7 +232,13 @@ pub fn fuzz() -> Result<()> {
 /// Sets up the endpoint coverage client according to the configuration, and initializes it
 /// and constructs a LibAFL observer and feedback
 #[allow(clippy::type_complexity)]
-fn setup_endpoint_coverage<'a, S: HasNamedMetadata, EM: EventFirer<I, S>, I, OT: MatchName>(
+fn setup_endpoint_coverage<
+    'a,
+    S: HasNamedMetadata + HasExecutions,
+    EM: EventFirer<I, S>,
+    I,
+    OT: MatchName,
+>(
     api: OpenAPI,
 ) -> Result<
     (
@@ -261,11 +262,11 @@ fn setup_endpoint_coverage<'a, S: HasNamedMetadata, EM: EventFirer<I, S>, I, OT:
         )
     }
     .track_novelties();
-    let endpoint_coverage_feedback: MapFeedback<
+    let endpoint_coverage_feedback: SimdMapFeedback<
         ExplicitTracking<StdMapObserver<'_, u8, false>, false, true>,
-        DifferentIsNovel,
         StdMapObserver<'_, u8, false>,
-        MaxReducer,
+        SimdMaxReducer,
+        u8x16,
     > = MaxMapFeedback::new(&endpoint_coverage_observer);
     Ok((
         endpoint_coverage_client,
@@ -277,11 +278,11 @@ fn setup_endpoint_coverage<'a, S: HasNamedMetadata, EM: EventFirer<I, S>, I, OT:
 type LineCovClientObserverFeedback<'a> = (
     Box<dyn CoverageClient>,
     ExplicitTracking<StdMapObserver<'a, u8, false>, true, true>,
-    MapFeedback<
+    SimdMapFeedback<
         ExplicitTracking<StdMapObserver<'a, u8, false>, true, true>,
-        DifferentIsNovel,
         StdMapObserver<'a, u8, false>,
-        MaxReducer,
+        SimdMaxReducer,
+        u8x16,
     >,
 );
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -179,7 +179,7 @@ impl OpenApiRequest {
                     resolve_single_parameter(body, parameter_values)?;
                 }
                 ParameterContents::Object(obj_contents) => {
-                    for (_key, nested_parameter) in obj_contents {
+                    for nested_parameter in obj_contents.values_mut() {
                         resolve_single_parameter(nested_parameter, parameter_values)?;
                     }
                 }
@@ -679,7 +679,6 @@ where
             })
         })
         .collect();
-    // new_params.sort_keys();
     input.parameters = new_params;
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -693,8 +693,9 @@ impl std::fmt::Display for OpenApiInput {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
     use std::collections::BTreeMap;
+
+    use serde_json::json;
 
     use super::{Body, Method, OpenApiRequest, ParameterContents};
 

--- a/src/input/parameter.rs
+++ b/src/input/parameter.rs
@@ -1,10 +1,10 @@
 use std::{
     borrow::Cow,
+    collections::BTreeMap,
     fmt::{Debug, Display, Formatter, Result},
 };
 
 use base64::{Engine as _, display::Base64Display, engine::general_purpose::STANDARD};
-use indexmap::IndexMap;
 use libafl_bolts::rands::Rand;
 use openapiv3::Parameter;
 use reqwest::header::HeaderValue;
@@ -22,7 +22,7 @@ use super::new_rand_input;
 ///
 /// See also: dependency graph module
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Hash)]
 pub enum SimpleValue {
     Null,
     Bool(bool),
@@ -59,7 +59,7 @@ impl Display for SimpleValue {
 }
 
 /// The contents of a parameter or of the body of an HTTP request made by the fuzzer.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Hash)]
 #[serde(tag = "DataType", content = "Contents")]
 pub enum ParameterContents {
     /// If the parameter type is one of `object`, `array` or `leaf_value`, it is a
@@ -67,7 +67,7 @@ pub enum ParameterContents {
     /// Mutators can attempt to mutate it using knowledge of the type, i.e. numbers
     /// will always be mutated into other numbers, and array elements can be shuffled.
     #[serde(rename = "Object")]
-    Object(IndexMap<String, ParameterContents>),
+    Object(BTreeMap<String, ParameterContents>),
     #[serde(rename = "Array")]
     Array(Vec<ParameterContents>),
     #[serde(rename = "PrimitiveValue")]
@@ -226,8 +226,8 @@ impl Display for ParameterContents {
     }
 }
 
-impl From<IndexMap<String, ParameterContents>> for ParameterContents {
-    fn from(value: IndexMap<String, ParameterContents>) -> Self {
+impl From<BTreeMap<String, ParameterContents>> for ParameterContents {
+    fn from(value: BTreeMap<String, ParameterContents>) -> Self {
         ParameterContents::Object(value)
     }
 }

--- a/src/input/serde_helpers.rs
+++ b/src/input/serde_helpers.rs
@@ -4,8 +4,9 @@
 //! and the request body, but internally they are the same type. This requires a
 //! conversion to an intermediate type, which happens in this module.
 
+use std::collections::BTreeMap;
+
 use base64::{Engine as _, engine::general_purpose::STANDARD as base64};
-use indexmap::IndexMap;
 use serde::{
     de::{self, Deserialize, Deserializer},
     ser::{Serialize, Serializer},
@@ -36,8 +37,8 @@ pub struct SerializableOpenApiRequest {
 
     #[serde(default, skip_serializing_if = "Body::is_empty")]
     body: Body,
-    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-    parameters: IndexMap<(String, ParameterKind), ParameterContents>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    parameters: BTreeMap<(String, ParameterKind), ParameterContents>,
 }
 
 impl From<OpenApiRequest> for SerializableOpenApiRequest {

--- a/src/monitors.rs
+++ b/src/monitors.rs
@@ -53,17 +53,13 @@ where
     ) -> Result<(), Error> {
         let config = Configuration::must_get();
         let total_time = current_time() - self.start_time;
-        let objective_size;
-        let total_execs;
-        let execs_per_sec_pretty;
-        let corpus_size;
-        {
-            let global_stats = client_stats_mgr.global_stats();
-            objective_size = global_stats.objective_size;
-            total_execs = global_stats.total_execs;
-            corpus_size = global_stats.corpus_size;
-            execs_per_sec_pretty = global_stats.execs_per_sec_pretty.to_owned();
-        }
+
+        let global_stats = client_stats_mgr.global_stats();
+        let objective_size = global_stats.objective_size;
+        let total_execs = global_stats.total_execs;
+        let corpus_size = global_stats.corpus_size;
+        let execs_per_sec_pretty = global_stats.execs_per_sec_pretty.to_owned();
+
         let client_stats = &client_stats_mgr.client_stats()[&ClientId(0)];
         let output_string = match config.output_format {
             OutputFormat::Json => json!({

--- a/src/monitors.rs
+++ b/src/monitors.rs
@@ -4,12 +4,14 @@
 use core::{time, time::Duration};
 use std::{borrow::Cow, fmt};
 
-use libafl::monitors::stats::{
-    AggregatorOps, ClientStats, ClientStatsManager, UserStats, UserStatsValue,
+use libafl::{
+    alloc::fmt::Debug,
+    monitors::{
+        Monitor,
+        stats::{AggregatorOps, ClientStats, ClientStatsManager, UserStats, UserStatsValue},
+    },
 };
-use libafl::{alloc::fmt::Debug, monitors::Monitor};
-use libafl_bolts::Error;
-use libafl_bolts::{ClientId, current_time, format_duration};
+use libafl_bolts::{ClientId, Error, current_time, format_duration};
 use serde_json::json;
 
 use crate::configuration::{Configuration, OutputFormat};

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -94,6 +94,14 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }
 
 fn field_names(api: &OpenAPI, request_body: &RequestBody) -> Option<Vec<String>> {

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -1,9 +1,8 @@
 //! Mutates a request series by adding a new request to it. The new request is taken
 //! at random from the API specification.
 
-use std::{borrow::Cow, convert::TryInto};
+use std::{borrow::Cow, collections::BTreeMap, convert::TryInto};
 
-use indexmap::IndexMap;
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
@@ -60,7 +59,7 @@ where
             api.operations().nth(new_path_i).unwrap();
         let (method, path) = (new_method.try_into().unwrap(), new_path.to_owned());
 
-        let mut parameters: IndexMap<(String, ParameterKind), ParameterContents> = new_op
+        let parameters: BTreeMap<(String, ParameterKind), ParameterContents> = new_op
             .parameters
             .iter()
             // Keep only concrete values and valid references
@@ -69,8 +68,7 @@ where
             .map(|param| (param.data.name.clone(), param.into()))
             .map(|name_kind| (name_kind, ParameterContents::Bytes(new_rand_input(rand))))
             .collect();
-        parameters.sort_keys();
-        let body_contents: Option<IndexMap<String, ParameterContents>> = new_op
+        let body_contents: Option<BTreeMap<String, ParameterContents>> = new_op
             .request_body
             .as_ref()
             .and_then(|ref_or_body| ref_or_body.resolve(api).ok())

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, collections::BTreeMap, convert::TryInto};
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
 };
 use libafl_bolts::{Named, rands::Rand};
@@ -95,11 +96,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -100,7 +100,7 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }
 

--- a/src/openapi_mutator/break_link.rs
+++ b/src/openapi_mutator/break_link.rs
@@ -64,6 +64,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/openapi_mutator/break_link.rs
+++ b/src/openapi_mutator/break_link.rs
@@ -58,4 +58,12 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/break_link.rs
+++ b/src/openapi_mutator/break_link.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
     state::HasRand,
 };
@@ -59,11 +60,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/different_method.rs
+++ b/src/openapi_mutator/different_method.rs
@@ -106,4 +106,12 @@ where
 
         Ok(MutationResult::Mutated)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/different_method.rs
+++ b/src/openapi_mutator/different_method.rs
@@ -112,6 +112,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/openapi_mutator/different_method.rs
+++ b/src/openapi_mutator/different_method.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, convert::TryInto};
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
 };
 use libafl_bolts::{Named, rands::Rand};
@@ -107,11 +108,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/different_path.rs
+++ b/src/openapi_mutator/different_path.rs
@@ -77,4 +77,12 @@ where
         // contains two identical paths. Still, it's best not to hang.
         Ok(MutationResult::Skipped)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/different_path.rs
+++ b/src/openapi_mutator/different_path.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, convert::TryInto};
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
 };
 use libafl_bolts::{Named, rands::Rand};
@@ -78,11 +79,7 @@ where
         Ok(MutationResult::Skipped)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/different_path.rs
+++ b/src/openapi_mutator/different_path.rs
@@ -83,6 +83,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/openapi_mutator/duplicate_request.rs
+++ b/src/openapi_mutator/duplicate_request.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
     state::HasRand,
 };
@@ -66,11 +67,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/duplicate_request.rs
+++ b/src/openapi_mutator/duplicate_request.rs
@@ -65,4 +65,12 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/duplicate_request.rs
+++ b/src/openapi_mutator/duplicate_request.rs
@@ -71,6 +71,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/openapi_mutator/establish_link.rs
+++ b/src/openapi_mutator/establish_link.rs
@@ -101,8 +101,12 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
-    
-    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<libafl::corpus::CorpusId>) -> Result<(), Error> {
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
         todo!()
     }
 }

--- a/src/openapi_mutator/establish_link.rs
+++ b/src/openapi_mutator/establish_link.rs
@@ -101,4 +101,8 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
+    
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<libafl::corpus::CorpusId>) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/establish_link.rs
+++ b/src/openapi_mutator/establish_link.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
 };
 use libafl_bolts::Named;
@@ -102,11 +103,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/establish_link.rs
+++ b/src/openapi_mutator/establish_link.rs
@@ -107,6 +107,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/openapi_mutator/mod.rs
+++ b/src/openapi_mutator/mod.rs
@@ -200,7 +200,7 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }
 

--- a/src/openapi_mutator/mod.rs
+++ b/src/openapi_mutator/mod.rs
@@ -194,8 +194,12 @@ where
             OpenApiMutator::Series(b) => b.mutate(state, input),
         }
     }
-    
-    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<libafl::corpus::CorpusId>) -> Result<(), Error> {
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
         todo!()
     }
 }

--- a/src/openapi_mutator/mod.rs
+++ b/src/openapi_mutator/mod.rs
@@ -194,6 +194,10 @@ where
             OpenApiMutator::Series(b) => b.mutate(state, input),
         }
     }
+    
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<libafl::corpus::CorpusId>) -> Result<(), Error> {
+        todo!()
+    }
 }
 
 /// Mutate leaf value in-place

--- a/src/openapi_mutator/remove_request.rs
+++ b/src/openapi_mutator/remove_request.rs
@@ -72,6 +72,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/openapi_mutator/remove_request.rs
+++ b/src/openapi_mutator/remove_request.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
     state::HasRand,
 };
@@ -67,11 +68,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/remove_request.rs
+++ b/src/openapi_mutator/remove_request.rs
@@ -66,4 +66,12 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/string_interesting.rs
+++ b/src/openapi_mutator/string_interesting.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 
 use libafl::{
     Error,
+    corpus::CorpusId,
     inputs::{BytesInput, ResizableMutator},
     mutators::{MutationResult, Mutator},
     state::HasRand,
@@ -48,11 +49,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/string_interesting.rs
+++ b/src/openapi_mutator/string_interesting.rs
@@ -47,4 +47,12 @@ where
         input.extend(state.rand_mut().choose(INTERESTING_STR).unwrap());
         Ok(MutationResult::Mutated)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/string_interesting.rs
+++ b/src/openapi_mutator/string_interesting.rs
@@ -53,6 +53,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/openapi_mutator/swap_requests.rs
+++ b/src/openapi_mutator/swap_requests.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 pub use libafl::mutators::mutations::*;
 use libafl::{
     Error,
+    corpus::CorpusId,
     mutators::{MutationResult, Mutator},
     state::HasRand,
 };
@@ -73,11 +74,7 @@ where
         Ok(MutationResult::Mutated)
     }
 
-    fn post_exec(
-        &mut self,
-        _state: &mut S,
-        _new_corpus_id: Option<libafl::corpus::CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/openapi_mutator/swap_requests.rs
+++ b/src/openapi_mutator/swap_requests.rs
@@ -72,4 +72,12 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
+
+    fn post_exec(
+        &mut self,
+        _state: &mut S,
+        _new_corpus_id: Option<libafl::corpus::CorpusId>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }

--- a/src/openapi_mutator/swap_requests.rs
+++ b/src/openapi_mutator/swap_requests.rs
@@ -78,6 +78,6 @@ where
         _state: &mut S,
         _new_corpus_id: Option<libafl::corpus::CorpusId>,
     ) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,10 +11,10 @@ use libafl::{
     feedbacks::StateInitializer,
     inputs::Input,
     schedulers::powersched::SchedulerMetadata,
-    stages::{HasCurrentStageId, StageId},
+    stages::StageId,
     state::{
-        HasCorpus, HasExecutions, HasImported, HasLastFoundTime, HasLastReportTime, HasMaxSize,
-        HasRand, HasSolutions, HasStartTime, Stoppable,
+        HasCorpus, HasCurrentStageId, HasExecutions, HasImported, HasLastFoundTime,
+        HasLastReportTime, HasMaxSize, HasRand, HasSolutions, HasStartTime, Stoppable,
     },
 };
 use libafl_bolts::{


### PR DESCRIPTION
Closes #101 

Upgrades libafl (and libafl-bolts) from 0.15.0 to 0.15.3.

Main changes:

## 0.15.0 -> 0.15.2

(I forgot to remove some commented-out code, and cleaned it up in the second commit).

- LibAFL's `Input` must now implement `Hash`, so in our `OpenApiInput`s I switched from using `IndexMap` to `BTreeMap`, since this already implements `Hash`. The choice of `IndexMap` was rather arbitrary way back iirc, perhaps just because it was already being used in other places and performance did not seem like an issue. Either way, we do not care about insertion order so that feature of `IndexMap` will not be missed. The different maps do have some different functions (`remove_entry` instead of `swap_remove_entry`, no more `IndexMut`) which did require small changes.
- LibAFL changed `Monitor::display` to require a `ClientStatsManager` which contains both global and client stats. Changes (in monitors.rs) were pretty straightforward, I chose to pre-assign variables from global_stats since both `global_stats()` and `client_stats()` require a mutable self-borrow. The `execs_per_sec_pretty`-function is also part of the `ClientStatsManager` now, which led to the small change in `req_execs_per_sec`.

## 0.15.2 -> 0.15.3

- Instead of `Event`s, `EventWithStats` is now used. This wraps the `Event` together with `ExecStats`. The `time` and `executions` of `ExecStats` are documented by LibAFL as "The time of generation of the [`Event`]" and "The executions of this client". AFAIK we have just a single client.
- `Event::UpdateExecStats` disappeared. I use the "dummy" `Heartbeat` event instead, with the `ExecStats` carrying the "payload". 
- `mutators::StdScheduledMutator` was renamed to `HavocScheduledMutator`.
- The `simd` (single instruction multiple data) feature is enabled by default for libafl, this is a CPU optimization. LibAFL introduced Simd-variants of certain types. As it is, this MR assumes WuppieFuzz will only use libafl with the `simd` feature enabled (we would have to use similar guards as libafl does to check for the feature - this may actually be a good idea, who knows on which systems the SIMD-feature might be disabled).
- `Mutator` requires a `post_exec` function, I left these as `todo!` for now rather than `unimplemented!`. I don't think we currently have a use-case (nor a good understanding of how this works) for mutating after an execution happened.