### PR TITLE
Fix error 'attempt to multiply with overflow'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   have exactly one element in [#144](https://github.com/TNO-S3/WuppieFuzz/pull/144)
 - Improved corpus loading and fixed fallback when corpus loading fails in
   [#147](https://github.com/TNO-S3/WuppieFuzz/pull/147)
+- Multiply overflow in corpus generation fixed in [#108](https://github.com/TNO-S3/WuppieFuzz/pull/108)
 
 # v1.2.0 (2025-02-21)
 

--- a/src/openapi/examples.rs
+++ b/src/openapi/examples.rs
@@ -906,7 +906,7 @@ pub fn openapi_inputs_from_ops<'a>(
     let total_combinations: usize = concrete_requests
         .iter()
         .try_fold(1, |acc: usize, elem| acc.checked_mul(elem.len()))
-        .ok_or("Error")?;
+        .ok_or("Corpus generation would generate billions of inputs, fall back to simple examples.")?;
     if total_combinations > 10000 {
         return Err(format!(
             "Corpus generation would try to create {total_combinations} inputs, fall back to simple examples."

--- a/src/openapi/examples.rs
+++ b/src/openapi/examples.rs
@@ -906,7 +906,9 @@ pub fn openapi_inputs_from_ops<'a>(
     let total_combinations: usize = concrete_requests
         .iter()
         .try_fold(1, |acc: usize, elem| acc.checked_mul(elem.len()))
-        .ok_or("Corpus generation would generate billions of inputs, fall back to simple examples.")?;
+        .ok_or(
+            "Corpus generation would generate billions of inputs, fall back to simple examples.",
+        )?;
     if total_combinations > 10000 {
         return Err(format!(
             "Corpus generation would try to create {total_combinations} inputs, fall back to simple examples."

--- a/src/openapi/examples.rs
+++ b/src/openapi/examples.rs
@@ -905,7 +905,7 @@ pub fn openapi_inputs_from_ops<'a>(
     // deduplicate_same_reference_requests(&mut concrete_requests, &subgraph, &sorted_nodes);
     let total_combinations: usize = concrete_requests
         .iter()
-        .fold(1, |acc, elem| acc * elem.len());
+        .try_fold(1, |acc: usize, elem| acc.checked_mul(elem.len())).ok_or("Error")?;
     if total_combinations > 10000 {
         return Err(format!(
             "Corpus generation would try to create {total_combinations} inputs, fall back to simple examples."

--- a/src/openapi/examples.rs
+++ b/src/openapi/examples.rs
@@ -905,7 +905,8 @@ pub fn openapi_inputs_from_ops<'a>(
     // deduplicate_same_reference_requests(&mut concrete_requests, &subgraph, &sorted_nodes);
     let total_combinations: usize = concrete_requests
         .iter()
-        .try_fold(1, |acc: usize, elem| acc.checked_mul(elem.len())).ok_or("Error")?;
+        .try_fold(1, |acc: usize, elem| acc.checked_mul(elem.len()))
+        .ok_or("Error")?;
     if total_combinations > 10000 {
         return Err(format!(
             "Corpus generation would try to create {total_combinations} inputs, fall back to simple examples."


### PR DESCRIPTION
Running the following command:
```
 wuppiefuzz output-corpus --openapi-spec openapi.yml corpus
```
results in an error. This was discovered for a relatively large OpenAPI spec. This leads to an overflow in the "usize" variable. I also tried the "u128" variable size, but that still causes an overflow. In fact, the "acc" variable became as large as 295617658828691846632166420412766595202 before crashing.

The fix performs a "checked_mul" to test for overflows before continuing. If an overflow is detected, an error is returned and the minimal corpus is used.