### PR TITLE
Jacoco single exec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ## Features
 
-- Added unit tests for mutators in 
+- Added unit tests for mutators in
   [#100](https://github.com/TNO-S3/WuppieFuzz/pull/100)
 
 ## Fixes
 
 - Updated [LibAFL](https://github.com/AFLplusplus/LibAFL) to 0.15.3 in
   [#107](https://github.com/TNO-S3/WuppieFuzz/pull/107)
+- Use a single file to store Jacoco exec data.
 
 # v1.2.0 (2025-02-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 - Updated [LibAFL](https://github.com/AFLplusplus/LibAFL) to 0.15.3 in
   [#107](https://github.com/TNO-S3/WuppieFuzz/pull/107)
-- Use a single file to store Jacoco exec data.
+- Use a single file to store Jacoco exec data in
+  [#114](https://github.com/TNO-S3/WuppieFuzz/pull/114).
 
 # v1.2.0 (2025-02-21)
 

--- a/src/coverage_clients/jacoco.rs
+++ b/src/coverage_clients/jacoco.rs
@@ -171,7 +171,6 @@ impl<'a> JacocoCoverageClient<'a> {
             let file_path = output_dir.join("jacoco_all.exec");
             let mut file = OpenOptions::new()
                 .create(true)
-                .write(true)
                 .append(true)
                 .truncate(false)
                 .open(&file_path)

--- a/src/coverage_clients/jacoco.rs
+++ b/src/coverage_clients/jacoco.rs
@@ -61,7 +61,6 @@ pub struct JacocoCoverageClient<'a> {
     latest_coverage_information: Vec<u8>,
     jacoco_dump_output_dir: Option<PathBuf>,
     jacoco_prefix_filter: &'a Option<String>,
-    dump_index: usize,
 }
 
 struct JacocoCoverageSegment {
@@ -135,7 +134,6 @@ impl<'a> JacocoCoverageClient<'a> {
             latest_coverage_information: Vec::new(),
             jacoco_dump_output_dir,
             jacoco_prefix_filter: jacoco_prefix,
-            dump_index: 0,
         };
         Ok(result)
     }
@@ -168,13 +166,14 @@ impl<'a> JacocoCoverageClient<'a> {
 
     fn dump_jacoco_coverage_to_file(&mut self) {
         if let Some(ref output_dir) = self.jacoco_dump_output_dir {
-            let file_path = output_dir.join(format!("jacoco_{}.exec", self.dump_index));
-            self.dump_index += 1;
-
+            // Coverage is all written to the same file; jacoco coverage
+            // can simply be concatenated. We merge everything afterwards.
+            let file_path = output_dir.join("jacoco_all.exec");
             let mut file = OpenOptions::new()
                 .create(true)
                 .write(true)
-                .truncate(true)
+                .append(true)
+                .truncate(false)
                 .open(&file_path)
                 .unwrap_or_else(|err| panic!("Could not create file {file_path:?}: {err}"));
 
@@ -386,9 +385,7 @@ impl CoverageClient for JacocoCoverageClient<'_> {
                 "Trying to generate a Jacoco report, but there is no directory with Jacoco dump files"
             ),
         };
-
-        let jacoco_exec_path = jacoco_dump_dir.join("jacoco_report.exec");
-
+        let jacoco_merged_path = jacoco_dump_dir.join("jacoco_merged.exec");
         std::process::Command::new("java")
             .args(["-jar", "coverage_agents/java/jacococli.jar"])
             .arg("merge")
@@ -399,7 +396,7 @@ impl CoverageClient for JacocoCoverageClient<'_> {
                     .map(|entry| entry.path()),
             )
             .arg("--destfile")
-            .arg(&jacoco_exec_path)
+            .arg(&jacoco_merged_path)
             .status()
             .expect("Could not generate jacoco report, merge command of the jacococli.jar failed.");
 
@@ -415,7 +412,7 @@ impl CoverageClient for JacocoCoverageClient<'_> {
             .arg(source_dir)
             .arg("--html")
             .arg(jacoco_html_path)
-            .arg(jacoco_exec_path)
+            .arg(jacoco_merged_path)
             .status()
             .expect(
                 "Could not generate jacoco report, report command of the jacococli.jar failed.",


### PR DESCRIPTION
Closes #41 

[It turns out that Jacoco exec files can simply be all concatenated together.](https://github.com/jacoco/jacoco/issues/1914)
This PR makes it so that we only write a single exec file (`jacoco_all.exec`), which is finally merged to get the union of all coverage in a new file (`jacoco_merged.exec`). Information about individual "sessions" is still accessible in the `jacoco_all.exec` file using `jacococli.jar`.

As far as I know the current writing of individual exec files is not used anywhere. Of course some users might have been relying on these individual files, but staying backwards compatible and making the single-file mode optional seems like a worse idea than just forcing these hypothetical users to update their tooling.