### PR TITLE
Minimal support for SchemaKind::AllOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   [#100](https://github.com/TNO-S3/WuppieFuzz/pull/100)
 - Adds support for overriding the target server from the CLI in
   [#111](https://github.com/TNO-S3/WuppieFuzz/pull/111)
-- Generate example parameters for the OpenAPI `allOf` keyword with just a single schema.
-  [#118](https://github.com/TNO-S3/WuppieFuzz/pull/118)
+- Generate example parameters for the OpenAPI `allOf` keyword with just a
+  single schema in [#118](https://github.com/TNO-S3/WuppieFuzz/pull/118)
 
 ## Fixes
 

--- a/src/openapi/examples.rs
+++ b/src/openapi/examples.rs
@@ -292,7 +292,7 @@ fn log_schema_debug(schema: &Schema) {
     if !log::log_enabled!(log::Level::Debug) {
         log::warn!("To output the schema, run with --log-level=debug.");
     }
-    log::debug!("{:?}", schema);
+    log::debug!("{schema:?}");
 }
 
 // Attempts to build a value that matches the given schema using default values


### PR DESCRIPTION
The `example_from_schema` function in `src/openapi/examples.rs` matches on `schema.kind`, and returns examples for some but not all `SchemaKind`s. So far, we returned `None` for the `AllOf`, `Any` and `Not` kinds because it is not easy/clear how to construct examples for these. In a practical case I had an API specified `allOf` with only one element, and I figured in this case we can easily generate an example. That's the main contribution of thie PR.

In the cases where no example is generated I've added warnings. It seems problematic to not generate an example value, since (as far as I can tell and test) if a field is not present in any request, it does not get added randomly based on the spec later on. See the `mutate` function in `src/openapi_mutator/mod.rs`: an input is mutated by choosing a random parameter from the ones already present in a previous input.