### PR TITLE
Support logging in the output-corpus subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   [#111](https://github.com/TNO-S3/WuppieFuzz/pull/111)
 - Generate example parameters for the OpenAPI `allOf` keyword with just a
   single schema in [#118](https://github.com/TNO-S3/WuppieFuzz/pull/118)
+- Support logging in the output-corpus subcommand in [#119](https://github.com/TNO-S3/WuppieFuzz/pull/119)
 
 ## Fixes
 

--- a/src/initial_corpus/dependency_graph/mod.rs
+++ b/src/initial_corpus/dependency_graph/mod.rs
@@ -15,7 +15,6 @@ use std::{
     path::Path,
 };
 
-use log::warn;
 use openapiv3::{OpenAPI, StatusCode};
 use petgraph::{
     prelude::{DiGraph, NodeIndex},
@@ -84,9 +83,10 @@ fn ops_from_subgraph<'a>(
         Ok(nodes) => nodes,
         Err(cycle) => {
             let operation = &subgraph[cycle.node_id()];
-            warn!(
+            log::warn!(
                 "While building initial corpus from the API specification, found operation with a self-cycle {} {}",
-                operation.method, operation.path
+                operation.method,
+                operation.path
             );
             return Err(cycle);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,11 +89,16 @@ pub fn main() -> Result<()> {
             corpus_directory,
             openapi_spec,
             report_path,
-        } => Ok(initial_corpus::generate_corpus_to_files(
-            &*get_api_spec(openapi_spec)?,
-            corpus_directory,
-            report_path.as_deref(),
-        )),
+            log_level: _,
+        } => {
+            let config = &Configuration::get().map_err(anyhow::Error::msg)?;
+            setup_logging(config);
+            Ok(initial_corpus::generate_corpus_to_files(
+                &*get_api_spec(openapi_spec)?,
+                corpus_directory,
+                report_path.as_deref(),
+            ))
+        }
         Commands::Reproduce { crash_file, .. } => reproducer::reproduce(crash_file),
         Commands::Fuzz { .. } => fuzzer::fuzz(),
     }


### PR DESCRIPTION
While debugging corpus generation I noticed my logging statements had no effect. The reason was that `setup_logging` did not get called for the `output-corpus` subcommand, which in turn had to do with the `log-level` parameter being tied to the `Configuration`, which was originally meant for fuzzing only. Luckily the config mechanism already used a `PartialConfiguration` in which all fields are optional.

This PR adds logging to the `output-corpus` subcommand by using the `PartialConfiguration`. Almost all of its fields are set to `None` in this case, but this does seem like a clear and easy solution anyway. 