### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,12 @@ RUN apt-get update \
     && apt-get install -qy cmake clang \
     && rm -rf /var/lib/apt/lists/*
 
-USER fuzzer
-
 COPY . .
 
 RUN cargo build --release
 
 FROM debian:bookworm-slim AS wuppiefuzz
+USER fuzzer
 WORKDIR /app
 COPY --from=builder /app/target/release/wuppiefuzz /app/wuppiefuzz
 


### PR DESCRIPTION
The Docker image did not build anymore for me, probably since Z3 was introduced.
I've added its dependencies and copy the WuppieFuzz binary out of a builder image into a final, slim image.

Extra Docker-fu suggestions are welcome!