### PR TITLE
Type-based fallback if schema-based fails

### DIFF
--- a/src/initial_corpus/dependency_graph/mod.rs
+++ b/src/initial_corpus/dependency_graph/mod.rs
@@ -65,7 +65,6 @@ pub fn initial_corpus_from_api(api: &Spec) -> Vec<OpenApiInput> {
                             log::warn!("{err} - falling back to single example generation.");
                         })
                         .unwrap_or(vec![openapi_example_input_from_ops(api, ops.into_iter())]);
-
                 inputs.into_iter().flat_map(move |input| {
                     add_references_to_openapi_input(&subgraph, &idxs, &input)
                 })

--- a/src/openapi/examples.rs
+++ b/src/openapi/examples.rs
@@ -50,7 +50,7 @@ fn example_body_contents(api: &Spec, operation: &Operation) -> Option<ParameterC
     // Get either application/json or form content, if neither is present return None.
     let media_type = None
         .or_else(|| body.content.get("application/json"))
-        .or_else(|| body.content.get("application/x-www-form-urlcontent"))?;
+        .or_else(|| body.content.get("application/x-www-form-urlencoded"))?;
 
     // Return None if the schema cannot be resolved
     let schema = media_type.schema.as_ref()?.resolve(api).ok()?;
@@ -484,7 +484,7 @@ fn interesting_params_from_schema(
             log::warn!("Schema has more than one_of schema: conflicting examples may be generated.")
         }
         result.extend(
-            [schema.one_of, schema.any_of]
+            [&schema.one_of, &schema.any_of]
                 .iter()
                 .flat_map(|schema_vec| {
                     schema_vec
@@ -503,6 +503,9 @@ fn interesting_params_from_schema(
                         })
                 }),
         );
+    }
+    if result.is_empty() {
+        result.extend(interesting_params_from_type(api, &schema, 0));
     }
     result
 }

--- a/src/openapi/examples.rs
+++ b/src/openapi/examples.rs
@@ -505,6 +505,8 @@ fn interesting_params_from_schema(
         );
     }
     if result.is_empty() {
+        // No suitable defaults or examples found; fall back to generating
+        // ones based on the type information embedded in the schema
         result.extend(interesting_params_from_type(api, &schema, 0));
     }
     result


### PR DESCRIPTION
I noticed that a corpus I generated had empty bodies. The reason was that `interesting_params_from_schema` only tries to create values from default, example(s) and things like one_of, any_of, etc. When this fails it seems much better to me to fall back to type-based generation of interesting values, to at least adhere to the format that the API prescribes.

This PR simply does that.

It also fixes a typo: x-www-form-urlcontent => x-www-form-urlencoded.