### PR TITLE
Fix endpoint coverage count for unexpected responses (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Fixes
 
+- Fix endpoint coverage count for unexpected responses in [#308](https://github.com/TNO-S3/WuppieFuzz/pull/308)
+
 # v1.5.0 (2026-04-30)
 
 ## Highlights

--- a/src/coverage_clients/endpoint.rs
+++ b/src/coverage_clients/endpoint.rs
@@ -146,7 +146,7 @@ impl EndpointCoverageClient {
         // during a run: once a triplet is inserted, its index must be unique since this
         // determines the mapping into the AFL-coverage maps.
         assert!(index / 8 < MAP_SIZE, "Coverage map is full");
-        self.len = std::cmp::max(self.len, index);
+        self.len = std::cmp::max(self.len, index + 1);
         // Map the method-path-status triplets via their index to *bits*, not bytes.
         // Hence the bitwise operations, the first 8 indices get mapped into the first byte
         // and since we always *add* coverage, we can OR the corresponding bit into that byte.


### PR DESCRIPTION
Fix endpoint coverage count for unexpected responses ([#307](https://github.com/TNO-S3/WuppieFuzz/issues/307))

* Fix endpoint coverage denominator for unexpected responses

Endpoint coverage used the zero-based map index as the tracked length when an unexpected method/path/status tuple was inserted.

This made the denominator one too small, allowing invalid coverage ratios such as `5/4 (125%)`.

The tracked length now uses `index + 1`, so newly inserted unexpected response entries are included in the total endpoint count.

Fixes #307