### PR TITLE
Fixes coverage map updates and bit counting logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Fixes
 
+- Fix coverage map updates and bit counting logic in [#309](https://github.com/TNO-S3/WuppieFuzz/pull/309)
+
 # v1.5.0 (2026-04-30)
 
 ## Highlights

--- a/src/coverage_clients/lcov_client.rs
+++ b/src/coverage_clients/lcov_client.rs
@@ -217,7 +217,6 @@ impl LcovCoverageClient {
         match bit_idx.cmp(&MAP_SIZE) {
             cmp::Ordering::Less => {
                 self.cov_map[bit_idx] = val;
-                self.cov_map_total[bit_idx] = val;
             }
             cmp::Ordering::Equal => {
                 log::debug!(
@@ -251,8 +250,8 @@ impl LcovCoverageClient {
                     line,
                     count,
                     checksum: _,
-                } if count != 0 => {
-                    self.set_cov_bit(&source_path, line, 1);
+                } => {
+                    self.set_cov_bit(&source_path, line, u8::from(count != 0));
                 }
                 _ => (),
             }
@@ -361,7 +360,7 @@ impl CoverageClient for LcovCoverageClient {
             .cov_map_total
             .iter()
             .fold(0u64, |sum, val| sum + u64::from(val.count_ones()));
-        let total = self.first_unused_idx as u64 * 8;
+        let total = self.first_unused_idx as u64;
         // update the max coverage ratio
         self.max_ratio.0 = std::cmp::max(self.max_ratio.0, count);
         self.max_ratio.1 = std::cmp::max(self.max_ratio.1, total);


### PR DESCRIPTION
There are three changes with this pull request

The most obvious one is changing how the `total` is calculated in `max_coverage_ratio`

```rust
   fn max_coverage_ratio(&mut self) -> (u64, u64) {
        let count = self
            .cov_map_total
            .iter()
            .fold(0u64, |sum, val| sum + u64::from(val.count_ones()));
        let total = self.first_unused_idx as u64;
        // update the max coverage ratio
        self.max_ratio.0 = std::cmp::max(self.max_ratio.0, count);
        self.max_ratio.1 = std::cmp::max(self.max_ratio.1, total);
        self.max_ratio
    }
```

before this was done by multiplying the total by 8, which is a mistake because each mapped line uses one byte as a boolean slot, not eight independent coverage bits.
      
Before
```rust
 let total = self.first_unused_idx as u64 * 8;
```

Second change is removing the unnecessary assignment of the `cov_bit` to the total map

```rust
   cmp::Ordering::Less => {
        self.cov_map[bit_idx] = val;
        self.cov_map_total[bit_idx] = val;
    }
```
This is unnecessary since the total coverage map is merged with the cov_map a few lines under, and is not required in between steps.

The third and the debatable change is lcov_client.rs:254:

Mapping every LineData, including count == 0, changes the denominator from “lines ever covered” to “coverable/instrumented lines observed in LCOV”. That is probably the more precise coverage ratio, but it can lower reported ratios compared with the old implementation. If that is intended, this version is better.

Fixes https://github.com/TNO-S3/WuppieFuzz/issues/103

