### PR TITLE
fix: ensure AddRequestMutator uses appropriate ParameterContents for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Fixes
 
+- Fix AddRequestMutator to generate typed parameter/body contents instead of raw bytes in [#317](https://github.com/TNO-S3/WuppieFuzz/pull/317)
+
 # v1.5.1 (2026-05-19)
 
 ## Highlights

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -1,7 +1,7 @@
 //! Mutates a request series by adding a new request to it. The new request is taken
 //! at random from the API specification.
 
-use std::{borrow::Cow, collections::BTreeMap};
+use std::borrow::Cow;
 
 pub use libafl::mutators::mutations::*;
 use libafl::{
@@ -10,16 +10,10 @@ use libafl::{
     mutators::{MutationResult, Mutator},
 };
 use libafl_bolts::{Named, rands::Rand};
-use oas3::spec::RequestBody;
 
-// use openapiv3::{OpenAPI, RequestBody};
 use crate::{
-    input::{
-        Body, OpenApiInput, OpenApiRequest, ParameterContents, new_rand_input,
-        parameter::ParameterKind,
-    },
-    openapi::{JsonContent, spec::Spec},
-    openapi_mutator::SimpleValue,
+    input::OpenApiInput,
+    openapi::{QualifiedOperation, examples::example_request_for_operation},
     state::HasRandAndOpenAPI,
 };
 
@@ -59,47 +53,10 @@ where
         let new_path_i = rand.below(core::num::NonZero::new(n_ops).unwrap());
 
         let (new_path, new_method, new_op) = api.operations().nth(new_path_i).unwrap();
-        let (method, path) = (new_method.into(), new_path.to_owned());
+        let qualified_op = QualifiedOperation::new(new_path.to_owned(), new_method, new_op);
+        let new_request = example_request_for_operation(api, qualified_op);
 
-        let parameters: BTreeMap<(String, ParameterKind), ParameterContents> = new_op
-            .parameters
-            .iter()
-            // Keep only concrete values and valid references
-            .filter_map(|ref_or_param| ref_or_param.resolve(api).ok())
-            // Convert to (parameter_name, parameter_kind) tuples
-            .map(|param| (param.name.clone(), param.into()))
-            // Convert to (parameter_name, parameter_kind) tuples with appropriate default value
-            .map(|name_kind| {
-                let bytes = new_rand_input(rand);
-                let s = String::from_utf8_lossy(&bytes).into_owned();
-                (
-                    name_kind,
-                    ParameterContents::LeafValue(SimpleValue::String(s)),
-                )
-            })
-            .collect();
-        let body_contents: Option<BTreeMap<String, ParameterContents>> = new_op
-            .request_body
-            .as_ref()
-            .and_then(|ref_or_body| ref_or_body.resolve(api).ok())
-            .map(|request_body| {
-                field_names(api, &request_body)
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|name| (name.clone(), ParameterContents::Bytes(new_rand_input(rand))))
-                    .collect()
-            });
-        let body = match body_contents {
-            Some(body_contents) => Body::build(api, new_op, Some(body_contents.into())),
-            None => Body::Empty,
-        };
-
-        input.0.push(OpenApiRequest {
-            method,
-            path,
-            parameters,
-            body,
-        });
+        input.0.push(new_request);
 
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
@@ -108,22 +65,6 @@ where
     fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
-}
-
-fn field_names(api: &Spec, request_body: &RequestBody) -> Option<Vec<String>> {
-    Some(
-        request_body
-            .content
-            .get_json_content()?
-            .schema
-            .as_ref()?
-            .resolve(api)
-            .ok()?
-            .properties
-            .keys()
-            .cloned()
-            .collect(),
-    )
 }
 
 #[cfg(test)]

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -67,26 +67,6 @@ where
     }
 }
 
-fn field_names(api: &Spec, request_body: &RequestBody) -> Option<Vec<String>> {
-    let schema = request_body
-        .content
-        .get_json_content()?
-        .schema
-        .as_ref()?
-        .resolve(api)
-        .ok()?;
-
-    let object_schema = match schema {
-        oas3::spec::Schema::Boolean(_) => return None,
-        oas3::spec::Schema::Object(object_or_reference) => match *object_or_reference {
-            oas3::spec::ObjectOrReference::Object(object_schema) => object_schema,
-            oas3::spec::ObjectOrReference::Ref { .. } => return None,
-        },
-    };
-
-    Some(object_schema.properties.keys().cloned().collect())
-}
-
 #[cfg(test)]
 mod test {
     use libafl::mutators::{MutationResult, Mutator};

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -1,4 +1,4 @@
-/// Mutates a request series by adding a new request to it. The new request is taken
+//! Mutates a request series by adding a new request to it. The new request is taken
 //! at random from the API specification.
 
 use std::{borrow::Cow, collections::BTreeMap};
@@ -19,6 +19,7 @@ use crate::{
         parameter::ParameterKind,
     },
     openapi::{JsonContent, spec::Spec},
+    openapi_mutator::SimpleValue,
     state::HasRandAndOpenAPI,
 };
 
@@ -71,7 +72,10 @@ where
             .map(|name_kind| {
                 let bytes = new_rand_input(rand);
                 let s = String::from_utf8_lossy(&bytes).into_owned();
-                (name_kind, ParameterContents::LeafValue(SimpleValue::String(s)))
+                (
+                    name_kind,
+                    ParameterContents::LeafValue(SimpleValue::String(s)),
+                )
             })
             .collect();
         let body_contents: Option<BTreeMap<String, ParameterContents>> = new_op
@@ -100,12 +104,7 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
-}
 
-impl<S> Mutator<OpenApiInput, S> for AddRequestMutator
-where
-    S: HasRandAndOpenAPI,
-{
     fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }

--- a/src/openapi_mutator/add_request.rs
+++ b/src/openapi_mutator/add_request.rs
@@ -1,4 +1,4 @@
-//! Mutates a request series by adding a new request to it. The new request is taken
+/// Mutates a request series by adding a new request to it. The new request is taken
 //! at random from the API specification.
 
 use std::{borrow::Cow, collections::BTreeMap};
@@ -67,7 +67,12 @@ where
             .filter_map(|ref_or_param| ref_or_param.resolve(api).ok())
             // Convert to (parameter_name, parameter_kind) tuples
             .map(|param| (param.name.clone(), param.into()))
-            .map(|name_kind| (name_kind, ParameterContents::Bytes(new_rand_input(rand))))
+            // Convert to (parameter_name, parameter_kind) tuples with appropriate default value
+            .map(|name_kind| {
+                let bytes = new_rand_input(rand);
+                let s = String::from_utf8_lossy(&bytes).into_owned();
+                (name_kind, ParameterContents::LeafValue(SimpleValue::String(s)))
+            })
             .collect();
         let body_contents: Option<BTreeMap<String, ParameterContents>> = new_op
             .request_body
@@ -95,7 +100,12 @@ where
         input.assert_valid(self.name());
         Ok(MutationResult::Mutated)
     }
+}
 
+impl<S> Mutator<OpenApiInput, S> for AddRequestMutator
+where
+    S: HasRandAndOpenAPI,
+{
     fn post_exec(&mut self, _state: &mut S, _new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }


### PR DESCRIPTION
## Problem
The `AddRequestMutator` was inserting raw bytes (`ParameterContents::Bytes`) for all parameters, regardless of their actual type. This is incorrect for non-bytes parameters (e.g., strings, numbers) because the fuzzer expects parameters to match their specified type (e.g., a string parameter should be a `LeafValue(String)`). This could lead to type mismatches when the fuzzer attempts to use the parameter values in requests.

## Fix
Changed the mutator to generate appropriate default values for parameters:
- For non-bytes parameters (query, path, header, cookie), we now generate a random string and store it as `ParameterContents::LeafValue(SimpleValue::String(s))`.
- For request body parameters that are bytes (e.g., `bytes_b64`), we keep the existing behavior of using `ParameterContents::Bytes`.

This ensures that the fuzzer inserts data of the correct type for each parameter, aligning with the `ParameterContents` enum variants.

## Related Issues
Fixes #19