### PR TITLE
Corpus format extended support for nested enums in body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Fixes
 
+- Corpus format extended support for nested enums in body in [#328](https://github.com/TNO-S3/WuppieFuzz/pull/328)
 - Preserve integer values during YAML request deserialization in [#324](https://github.com/TNO-S3/WuppieFuzz/pull/324)
 
 # v1.5.1 (2026-05-19)

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -112,7 +112,7 @@ pub(crate) fn process_response(
 
 impl<OT> SequenceExecutor<OT>
 where
-    OT: for<'all> ObserversTuple<OpenApiInput, FuzzerState>,
+    OT: ObserversTuple<OpenApiInput, FuzzerState>,
 {
     /// Create a new SequenceExecutor.
     pub fn new(

--- a/src/input/serde_helpers.rs
+++ b/src/input/serde_helpers.rs
@@ -73,6 +73,10 @@ mod body_serde {
         value_to_body(value).map_err(D::Error::custom)
     }
 
+    /// Convert YAML `Value` to `Body` enum.
+    ///
+    /// Accepts either tagged values (`!ApplicationJson`) or singleton maps (`ApplicationJson: {...}`).
+    /// Strips `!` prefix from tags, extracts variant + inner value, then dispatches to `body_from_variant`.
     fn value_to_body(value: Value) -> Result<Body, serde_yaml::Error> {
         match value {
             Value::Tagged(tagged) => {
@@ -94,6 +98,10 @@ mod body_serde {
         }
     }
 
+    /// Map variant name to `Body` constructor, deserialize inner value.
+    ///
+    /// Valid variants: `Empty`, `TextPlain`, `ApplicationJson`, `XWwwFormUrlencoded`.
+    /// Each (except `Empty`) deserializes its paired `Value` using `serde_yaml::from_value`.
     fn body_from_variant(variant: &str, value: Value) -> Result<Body, serde_yaml::Error> {
         match variant {
             "Empty" => Ok(Body::Empty),

--- a/src/input/serde_helpers.rs
+++ b/src/input/serde_helpers.rs
@@ -26,6 +26,7 @@ pub struct SerializableOpenApiRequest {
     method: Method,
     path: String,
 
+    #[serde(with = "body_serde")]
     #[serde(default, skip_serializing_if = "Body::is_empty")]
     body: Body,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -50,6 +51,56 @@ impl From<SerializableOpenApiRequest> for OpenApiRequest {
             path: request.path,
             body: request.body,
             parameters: request.parameters,
+        }
+    }
+}
+
+mod body_serde {
+    use super::*;
+
+    pub fn serialize<S>(body: &Body, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serde_yaml::with::singleton_map::serialize(body, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Body, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        value_to_body(value).map_err(D::Error::custom)
+    }
+
+    fn value_to_body(value: Value) -> Result<Body, serde_yaml::Error> {
+        match value {
+            Value::Tagged(tagged) => {
+                let TaggedValue { tag, value } = *tagged;
+                body_from_variant(tag.to_string().trim_start_matches('!'), value)
+            }
+            Value::Mapping(map) if map.len() == 1 => {
+                let (variant, value) = map.into_iter().next().expect("map length checked above");
+                match variant {
+                    Value::String(variant) => body_from_variant(&variant, value),
+                    other => Err(Error::custom(format!(
+                        "body variant must be a string, got {other:?}"
+                    ))),
+                }
+            }
+            other => Err(Error::custom(format!(
+                "body must be a tagged value or singleton map, got {other:?}"
+            ))),
+        }
+    }
+
+    fn body_from_variant(variant: &str, value: Value) -> Result<Body, serde_yaml::Error> {
+        match variant {
+            "Empty" => Ok(Body::Empty),
+            "TextPlain" => Ok(Body::TextPlain(serde_yaml::from_value(value)?)),
+            "ApplicationJson" => Ok(Body::ApplicationJson(serde_yaml::from_value(value)?)),
+            "XWwwFormUrlencoded" => Ok(Body::XWwwFormUrlencoded(serde_yaml::from_value(value)?)),
+            other => Err(Error::custom(format!("unknown body variant {other}"))),
         }
     }
 }
@@ -207,7 +258,49 @@ impl<'de> Deserialize<'de> for ParameterContents {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::input::parameter::SimpleValue;
+    use crate::input::{OpenApiInput, parameter::SimpleValue};
+
+    #[test]
+    fn direct_string_body_serializes_without_nested_enum_error() {
+        let input = OpenApiInput(vec![OpenApiRequest {
+            method: Method::Post,
+            path: "/customers/{customerId}/documents".to_string(),
+            body: Body::ApplicationJson(ParameterContents::LeafValue(SimpleValue::String(
+                "Offer_Letter".to_string(),
+            ))),
+            parameters: BTreeMap::new(),
+        }]);
+
+        let yaml = serde_yaml::to_string(&input).expect("failed to serialize OpenApiInput");
+
+        assert!(yaml.contains("ApplicationJson"));
+        assert!(yaml.contains("!String Offer_Letter"));
+
+        let parsed: OpenApiInput = serde_yaml::from_str(&yaml).expect("failed to deserialize YAML");
+        match &parsed.0[0].body {
+            Body::ApplicationJson(ParameterContents::LeafValue(SimpleValue::String(value))) => {
+                assert_eq!(value, "Offer_Letter");
+            }
+            other => panic!("unexpected body value: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tagged_body_yaml_still_deserializes() {
+        let yaml = "- method: POST\n  path: /documents\n  body: !ApplicationJson\n    type: !String Offer_Letter\n";
+
+        let parsed: OpenApiInput = serde_yaml::from_str(yaml).expect("failed to deserialize YAML");
+
+        match &parsed.0[0].body {
+            Body::ApplicationJson(ParameterContents::Object(map)) => match map.get("type") {
+                Some(ParameterContents::LeafValue(SimpleValue::String(value))) => {
+                    assert_eq!(value, "Offer_Letter");
+                }
+                other => panic!("unexpected type value: {other:?}"),
+            },
+            other => panic!("unexpected body value: {other:?}"),
+        }
+    }
 
     #[test]
     fn yaml_integer_stays_integer_number() {

--- a/tutorial/CORPUS.md
+++ b/tutorial/CORPUS.md
@@ -80,9 +80,18 @@ parameters:
 
 ## Request Body
 
-The `body` field describes the payload `POST` and `PUT` requests. It is annotated with a MIME type using e.g. `!ApplicationJson`.
+The `body` field describes the payload of `POST` and `PUT` requests. It is annotated with a body kind such as `ApplicationJson`, `TextPlain`, or `XWwwFormUrlencoded`.
 
-### Example: Object Body
+New corpus files write the body kind as a singleton map:
+
+```yaml
+body:
+  ApplicationJson: <body_value_definition>
+```
+
+This representation is used instead of nested YAML tags so that body values can still carry their own explicit type tags, for example `!String`, `!Number`, `!Bool`, or `!Null`. This is important for preserving the difference between a string such as `"1"` and a number such as `1`.
+
+Older corpus files that use a tagged body are still accepted when reading corpus files:
 
 ```yaml
 body: !ApplicationJson
@@ -90,10 +99,46 @@ body: !ApplicationJson
   name: !String doggie
 ```
 
+### Example: Object Body
+
+```yaml
+body:
+  ApplicationJson:
+    id: !Number 0
+    name: !String doggie
+```
+
 ### Example: Array of Objects
 
 ```yaml
-body: !ApplicationJson
-- username !String 🎵
-- password !String password123
+body:
+  ApplicationJson:
+    - username: !String 🎵
+      password: !String password123
+    - username: !String user
+      password: !String password123
 ```
+
+### Example: Direct String Body
+
+Some OpenAPI specifications define the entire JSON request body as a primitive value, for example a string enum. In that case the corpus keeps both the body kind and the primitive value type:
+
+```yaml
+body:
+  ApplicationJson: !String Application_Form
+```
+
+This represents an `application/json` request body whose JSON payload is the string `"Application_Form"`.
+
+### Example: Preserving String vs Number
+
+Explicit value tags are preserved even when the YAML scalar text could be interpreted as another type:
+
+```yaml
+body:
+  ApplicationJson:
+    string_id: !String "1"
+    numeric_id: !Number 1
+```
+
+Here `string_id` is sent as the JSON string `"1"`, while `numeric_id` is sent as the JSON number `1`.


### PR DESCRIPTION
This should close #325 while retaining existing serialization/deserialization functionality.

@Equinox07, I do not have your full spec. Can you test whether this would do the trick and whether the output is sensible?

It would be extra nice if you could validate whether manual removal/resolving of nested enums produces similar results. 