### PR TITLE
Add support for crash_criteria in reproduce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Fixes
 
+- Add support for crash-criteria in reproduce command in [#332](https://github.com/TNO-S3/WuppieFuzz/pull/332)
 - Fix AddRequestMutator to generate typed parameter/body contents instead of raw bytes in [#317](https://github.com/TNO-S3/WuppieFuzz/pull/317)
 - Preserve integer values during YAML request deserialization in [#324](https://github.com/TNO-S3/WuppieFuzz/pull/324)
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -118,6 +118,11 @@ pub enum Commands {
         /// passed through an API specification.
         #[arg(long, value_parser, value_name = "STATIC_HEADERS.YAML")]
         header: Option<PathBuf>,
+        /// Which errors should be considered a bug while replaying this input.
+        ///
+        /// By default, all validation error variants are considered crashes.
+        #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]
+        crash_criteria: Option<Vec<ValidationErrorDiscriminants>>,
         // Manually added possible values below, since automatically showing possible values of an external (remote) enum
         // such as log::LevelFilter is not well supported.
         // See https://github.com/serde-rs/serde/issues/1301, https://github.com/serde-rs/serde/issues/723
@@ -283,6 +288,7 @@ impl Commands {
                 target,
                 authentication,
                 header,
+                crash_criteria,
                 log_level,
                 ..
             } => Ok(PartialConfiguration {
@@ -290,6 +296,7 @@ impl Commands {
                 target,
                 authentication,
                 header,
+                crash_criteria,
                 log_level,
                 ..Default::default()
             }),

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -119,6 +119,7 @@ pub enum Commands {
         #[arg(long, value_parser, value_name = "STATIC_HEADERS.YAML")]
         header: Option<PathBuf>,
         /// Which errors should be considered a bug while replaying this input.
+        /// See help for the `fuzz` command for a list of possible values.
         ///
         /// By default, all validation error variants are considered crashes.
         #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]


### PR DESCRIPTION
Apparently crash criteria was missing in reproduce. We need to be able to configure it similar to how we used it during fuzzing to properly reproduce it.