### PR TITLE
Crash dedup minimization feature

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -8,7 +8,7 @@ use std::{
 
 use clap::{Parser, Subcommand, ValueEnum, value_parser};
 use libafl::schedulers::powersched::BaseSchedule;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use strum::VariantArray;
 use url::Url;
 
@@ -21,6 +21,16 @@ const DEFAULT_LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
 lazy_static! {
     static ref CONFIGURATION: Result<Configuration, anyhow::Error> =
         Configuration::try_from(PartialConfiguration::get()?);
+}
+
+/// Selects which reproduced crash inputs are minimized during deduplication.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum MinimizationMode {
+    /// Minimize only the selected representative of each crash cluster.
+    Representative,
+    /// Minimize every reproduced crash file.
+    All,
 }
 
 /// Grey-box REST API Fuzzer written in Rust with LibAFL.
@@ -138,6 +148,9 @@ pub enum Commands {
         /// The directory to write deduplicated crash representatives to
         #[arg(long, value_parser, value_name = "OUTPUT_DIRECTORY")]
         output: PathBuf,
+        /// Minimize one representative per cluster, or every reproduced crash file.
+        #[arg(long, value_enum, value_name = "MODE", num_args = 0..=1, default_missing_value = "representative")]
+        minimize: Option<MinimizationMode>,
         /// The OpenAPI specification of the program under test
         #[arg(long, value_name = "OPENAPI_SPEC.YAML")]
         openapi_spec: Option<PathBuf>,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -125,6 +125,41 @@ pub enum Commands {
         #[arg(value_parser = clap::value_parser!(log::LevelFilter), long, value_enum, env = "LOG_LEVEL", ignore_case = true)]
         log_level: Option<log::LevelFilter>,
     },
+    /// Deduplicate crash files generated during an earlier fuzzing run
+    Dedup {
+        /// The path to a configuration file. If present, the configuration file is used
+        /// to configure the deduplication replay. Arguments given on the command line
+        /// take precedence over the configuration file.
+        #[arg(long, value_parser, value_name = "CONFIG_FILE.YAML")]
+        config: Option<PathBuf>,
+        /// The directory containing crash files to deduplicate
+        #[arg(value_name = "CRASH_DIRECTORY")]
+        crash_directory: PathBuf,
+        /// The directory to write deduplicated crash representatives to
+        #[arg(long, value_parser, value_name = "OUTPUT_DIRECTORY")]
+        output: PathBuf,
+        /// The OpenAPI specification of the program under test
+        #[arg(long, value_name = "OPENAPI_SPEC.YAML")]
+        openapi_spec: Option<PathBuf>,
+        /// The URL of the server to replay crashes against. This is usually specified in
+        /// the OpenAPI specification, but you can use this option to override it.
+        #[arg(value_parser=verify_url, long)]
+        target: Option<Url>,
+        /// How to log in to the API server. The value should be the name of a YAML file
+        /// that contains the login configuration. See login.md for information on how
+        /// to build one.
+        #[arg(long, value_parser, value_name = "AUTH.YAML")]
+        authentication: Option<PathBuf>,
+        /// Custom (static) headers that should be added to each replayed request.
+        #[arg(long, value_parser, value_name = "STATIC_HEADERS.YAML")]
+        header: Option<PathBuf>,
+        // Manually added possible values below, since automatically showing possible values of an external (remote) enum
+        // such as log::LevelFilter is not well supported.
+        // See https://github.com/serde-rs/serde/issues/1301, https://github.com/serde-rs/serde/issues/723
+        /// Log level to output. This flag takes precedence over the environment variable. [possible values: off, error, warn, debug, info, trace]
+        #[arg(value_parser = clap::value_parser!(log::LevelFilter), long, value_enum, env = "LOG_LEVEL", ignore_case = true)]
+        log_level: Option<log::LevelFilter>,
+    },
     /// Fuzz test an OpenAPI backend
     Fuzz {
         /// The path to a configuration file. If present, the configuration file is used
@@ -256,7 +291,8 @@ impl Commands {
         match self {
             Commands::VerifyAuth { config, .. }
             | Commands::Reproduce { config, .. }
-            | Commands::Fuzz { config, .. } => config.as_ref(),
+            | Commands::Fuzz { config, .. }
+            | Commands::Dedup { config, .. } => config.as_ref(),
             _ => None,
         }
     }
@@ -332,6 +368,21 @@ impl Commands {
                 header,
                 log_level,
                 jacoco_class_prefix,
+            }),
+            Commands::Dedup {
+                openapi_spec,
+                target,
+                authentication,
+                header,
+                log_level,
+                ..
+            } => Ok(PartialConfiguration {
+                openapi_spec,
+                target,
+                authentication,
+                header,
+                log_level,
+                ..Default::default()
             }),
             Commands::OutputCorpus {
                 corpus_directory: _,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -151,6 +151,23 @@ pub enum Commands {
         /// Minimize one representative per cluster, or every reproduced crash file.
         #[arg(long, value_enum, value_name = "MODE", num_args = 0..=1, default_missing_value = "representative")]
         minimize: Option<MinimizationMode>,
+        /// Which errors are considered a bug when replaying crash files.
+        ///
+        /// Accepts the same values as `wuppiefuzz fuzz --crash-criteria` (see that command's
+        /// help for a description of each error). This should match the crash criteria used
+        /// during the fuzzing run that produced the crash files; with a different (narrower)
+        /// criteria set, crash files may be reported as non-reproducible.
+        ///
+        /// By default, all error types are considered bugs.
+        #[arg(
+            value_parser,
+            long,
+            value_enum,
+            required = false,
+            ignore_case = true,
+            verbatim_doc_comment
+        )]
+        crash_criteria: Option<Vec<ValidationErrorDiscriminants>>,
         /// The OpenAPI specification of the program under test
         #[arg(long, value_name = "OPENAPI_SPEC.YAML")]
         openapi_spec: Option<PathBuf>,
@@ -388,6 +405,7 @@ impl Commands {
                 authentication,
                 header,
                 log_level,
+                crash_criteria,
                 ..
             } => Ok(PartialConfiguration {
                 openapi_spec,
@@ -395,6 +413,7 @@ impl Commands {
                 authentication,
                 header,
                 log_level,
+                crash_criteria,
                 ..Default::default()
             }),
             Commands::OutputCorpus {

--- a/src/crash_dedup/identity.rs
+++ b/src/crash_dedup/identity.rs
@@ -1,3 +1,9 @@
+//! Crash identity model used by dedup and minimization.
+//!
+//! This module defines coarse crash dimensions (exit kind, crash kind, status,
+//! endpoint, response class) and converts them into stable, orderable keys for
+//! cluster grouping.
+
 use crate::openapi::validate_response::ValidationErrorDiscriminants;
 
 /// Coarse category of failure observed while replaying a crash input.
@@ -133,6 +139,9 @@ pub struct CrashIdentity {
 
 impl CrashIdentity {
     /// Returns the full key used for crash clustering.
+    ///
+    /// Nice to know: key intentionally stores stringified fields so serialized
+    /// report output and map ordering stay stable across runs.
     pub fn cluster_key(&self) -> CrashClusterKey {
         CrashClusterKey {
             exit_kind: self.exit_kind.to_string(),

--- a/src/crash_dedup/identity.rs
+++ b/src/crash_dedup/identity.rs
@@ -1,0 +1,198 @@
+use crate::openapi::validate_response::ValidationErrorDiscriminants;
+
+/// Coarse category of failure observed while replaying a crash input.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CrashKind {
+    /// The target returned a server-side HTTP status code.
+    Http5xx,
+    /// The response violated the OpenAPI contract in a way configured as crashing.
+    Validation(ValidationErrorDiscriminants),
+    /// The response was classified as a crash without a more specific kind.
+    HttpResponseCrash,
+    /// The request timed out before a response was received.
+    TransportTimeout,
+    /// The client could not establish a connection to the target.
+    TransportConnectionError,
+    /// The client received a response it could not decode.
+    TransportDecodeError,
+    /// The client reported a transport error that does not fit a narrower bucket.
+    TransportUnknownError,
+}
+
+impl std::fmt::Display for CrashKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http5xx => f.write_str("http_5xx"),
+            Self::Validation(discriminant) => write!(f, "validation_{discriminant:?}"),
+            Self::HttpResponseCrash => f.write_str("http_response_crash"),
+            Self::TransportTimeout => f.write_str("transport_timeout"),
+            Self::TransportConnectionError => f.write_str("transport_connection_error"),
+            Self::TransportDecodeError => f.write_str("transport_decode_error"),
+            Self::TransportUnknownError => f.write_str("transport_unknown_error"),
+        }
+    }
+}
+
+/// Coarse classification of the response body or transport failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ResponseClass {
+    /// Body parsed as JSON.
+    Json,
+    /// Response had no body.
+    Empty,
+    /// Body was text that did not look like HTML or malformed JSON.
+    Plaintext,
+    /// Body looked like an HTML document.
+    Html,
+    /// Body looked JSON-shaped but failed to parse as JSON.
+    InvalidJson,
+    /// Body could not be classified as a supported textual format.
+    BinaryOrUnknown,
+    /// No response was received before the timeout.
+    TransportTimeout,
+    /// No response was received because the connection failed.
+    TransportConnectionError,
+    /// Response decoding failed at the transport/client layer.
+    TransportDecodeError,
+    /// Transport/client failure that does not fit a narrower bucket.
+    TransportUnknownError,
+}
+
+impl std::fmt::Display for ResponseClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::Json => "json",
+            Self::Empty => "empty",
+            Self::Plaintext => "plaintext",
+            Self::Html => "html",
+            Self::InvalidJson => "invalid_json",
+            Self::BinaryOrUnknown => "binary_or_unknown",
+            Self::TransportTimeout => "transport_timeout",
+            Self::TransportConnectionError => "transport_connection_error",
+            Self::TransportDecodeError => "transport_decode_error",
+            Self::TransportUnknownError => "transport_unknown_error",
+        };
+        f.write_str(value)
+    }
+}
+
+/// Whether replay observed a crash response or a timeout-like executor result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ObservedExitKind {
+    /// Replay observed a crashing response.
+    Crash,
+    /// Replay ended with a timeout-like executor result rather than a response crash.
+    Timeout,
+}
+
+impl std::fmt::Display for ObservedExitKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Crash => f.write_str("crash"),
+            Self::Timeout => f.write_str("timeout"),
+        }
+    }
+}
+
+/// Opaque key used to order and group crash observations.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CrashClusterKey {
+    exit_kind: String,
+    crash_kind: String,
+    http_status: Option<u16>,
+    validation_error_discriminant: Option<String>,
+    endpoint: Option<String>,
+    response_class: ResponseClass,
+}
+
+impl std::fmt::Display for CrashClusterKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}|{}|{}|{}|{}|{}",
+            self.exit_kind,
+            self.crash_kind,
+            self.http_status.map(|s| s.to_string()).unwrap_or_default(),
+            self.validation_error_discriminant.as_deref().unwrap_or(""),
+            self.endpoint.as_deref().unwrap_or(""),
+            self.response_class,
+        )
+    }
+}
+
+/// Coarse identity used to group crashes with similar characteristics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrashIdentity {
+    pub exit_kind: ObservedExitKind,
+    pub crash_kind: CrashKind,
+    pub http_status: Option<u16>,
+    pub validation_error_discriminant: Option<ValidationErrorDiscriminants>,
+    pub endpoint: Option<String>,
+    pub response_class: ResponseClass,
+}
+
+impl CrashIdentity {
+    /// Returns the full key used for crash clustering.
+    pub fn cluster_key(&self) -> CrashClusterKey {
+        CrashClusterKey {
+            exit_kind: self.exit_kind.to_string(),
+            crash_kind: self.crash_kind.to_string(),
+            http_status: self.http_status,
+            validation_error_discriminant: self
+                .validation_error_discriminant
+                .as_ref()
+                .map(|discriminant| format!("{discriminant:?}")),
+            endpoint: self.endpoint.clone(),
+            response_class: self.response_class,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> CrashIdentity {
+        CrashIdentity {
+            exit_kind: ObservedExitKind::Crash,
+            crash_kind: CrashKind::Http5xx,
+            http_status: Some(500),
+            validation_error_discriminant: None,
+            endpoint: Some("POST /users".into()),
+            response_class: ResponseClass::Json,
+        }
+    }
+
+    #[test]
+    fn cluster_key_is_stable_for_equal_identities() {
+        assert_eq!(identity().cluster_key(), identity().cluster_key());
+    }
+
+    #[test]
+    fn full_cluster_key_preserves_current_string_format() {
+        assert_eq!(
+            identity().cluster_key().to_string(),
+            "crash|http_5xx|500||POST /users|json"
+        );
+    }
+
+    #[test]
+    fn changed_identity_dimensions_change_the_cluster_key() {
+        let baseline = identity();
+
+        let mut different_endpoint = identity();
+        different_endpoint.endpoint = Some("GET /users".into());
+        assert_ne!(baseline.cluster_key(), different_endpoint.cluster_key());
+
+        let mut different_status = identity();
+        different_status.http_status = Some(502);
+        assert_ne!(baseline.cluster_key(), different_status.cluster_key());
+
+        let mut different_response_class = identity();
+        different_response_class.response_class = ResponseClass::Html;
+        assert_ne!(
+            baseline.cluster_key(),
+            different_response_class.cluster_key()
+        );
+    }
+}

--- a/src/crash_dedup/minimizer.rs
+++ b/src/crash_dedup/minimizer.rs
@@ -1,3 +1,9 @@
+//! Delta-debugging minimizer for replayable crash inputs.
+//!
+//! The minimizer removes one request at a time and accepts a candidate only when
+//! replay still crashes with same cluster key. Requests referenced by other
+//! requests are protected from removal.
+
 use anyhow::{Context, Result};
 use serde::Serialize;
 
@@ -33,6 +39,14 @@ pub struct MinimizationResult {
     pub report: MinimizationReport,
 }
 
+/// Minimize `input` while preserving `expected_cluster_key`.
+///
+/// Preconditions:
+/// - `replay` must be deterministic enough for identity comparison.
+/// - Baseline replay of input must produce a crash for requested key.
+///
+/// Returns failed result when baseline does not crash, crashes with different
+/// identity, or replay returns an error.
 pub fn minimize_with<Replay>(
     input: OpenApiInput,
     expected_cluster_key: &CrashClusterKey,
@@ -129,6 +143,7 @@ where
     }
 }
 
+/// Build a failed minimization result with structured report fields.
 pub fn failed(
     original_request_count: usize,
     candidate_replays: usize,
@@ -149,6 +164,10 @@ pub fn failed(
     }
 }
 
+/// Return cloned input with one request removed when safe.
+///
+/// Returns `None` when index is out of bounds, sequence has one request only,
+/// or another request contains a backreference to removed index.
 fn without_request(input: &OpenApiInput, request_index: usize) -> Option<OpenApiInput> {
     if input.0.len() <= 1 || request_index >= input.0.len() {
         return None;
@@ -167,6 +186,7 @@ fn without_request(input: &OpenApiInput, request_index: usize) -> Option<OpenApi
     Some(candidate)
 }
 
+/// Check whether request references request at `request_index`.
 fn request_references_index(request: &OpenApiRequest, request_index: usize) -> bool {
     request
         .parameters
@@ -178,6 +198,7 @@ fn request_references_index(request: &OpenApiRequest, request_index: usize) -> b
             .is_some_and(|body| parameter_references_index(body, request_index))
 }
 
+/// Recursively check whether parameter tree references request index.
 fn parameter_references_index(parameter: &ParameterContents, request_index: usize) -> bool {
     match parameter {
         ParameterContents::Object(values) => values
@@ -192,6 +213,7 @@ fn parameter_references_index(parameter: &ParameterContents, request_index: usiz
     }
 }
 
+/// Rewrite request backreference indexes after removing earlier request.
 fn rewrite_request_references_after_removal(
     request: &mut OpenApiRequest,
     removed_request_index: usize,
@@ -204,6 +226,7 @@ fn rewrite_request_references_after_removal(
     }
 }
 
+/// Recursively decrement backreference indexes greater than removed index.
 fn rewrite_parameter_references_after_removal(
     parameter: &mut ParameterContents,
     removed_request_index: usize,

--- a/src/crash_dedup/minimizer.rs
+++ b/src/crash_dedup/minimizer.rs
@@ -1,0 +1,305 @@
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::{
+    crash_dedup::{identity::CrashClusterKey, replay::ReplayOutcome},
+    input::{Body, OpenApiInput, OpenApiRequest, ParameterContents},
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MinimizationStatus {
+    Minimized,
+    Unchanged,
+    Failed,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct MinimizationReport {
+    pub status: MinimizationStatus,
+    pub original_request_count: usize,
+    pub minimized_request_count: usize,
+    pub candidate_replays: usize,
+    pub removed_request_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+}
+
+pub struct MinimizationResult {
+    pub input: Option<OpenApiInput>,
+    pub crashing_request_index: Option<usize>,
+    pub report: MinimizationReport,
+}
+
+pub fn minimize_with<Replay>(
+    input: OpenApiInput,
+    expected_cluster_key: &CrashClusterKey,
+    mut replay: Replay,
+) -> MinimizationResult
+where
+    Replay: FnMut(&OpenApiInput) -> Result<ReplayOutcome>,
+{
+    let original_request_count = input.0.len();
+    let baseline = match replay(&input).context("Replaying baseline representative") {
+        Ok(ReplayOutcome::Crash(baseline)) => baseline,
+        Ok(ReplayOutcome::Completed) => {
+            return failed(
+                original_request_count,
+                0,
+                String::from("Baseline input did not reproduce a crash"),
+            );
+        }
+        Ok(ReplayOutcome::Stopped(reason)) => {
+            return failed(
+                original_request_count,
+                0,
+                format!("Baseline replay stopped: {reason}"),
+            );
+        }
+        Err(error) => {
+            return failed(original_request_count, 0, format!("{error:#}"));
+        }
+    };
+    if baseline.identity.cluster_key() != *expected_cluster_key {
+        return failed(
+            original_request_count,
+            0,
+            String::from("Baseline input reproduced a different crash identity"),
+        );
+    }
+
+    let mut current = input;
+    let mut current_crashing_request_index = baseline.crashing_request_index;
+    let mut candidate_replays = 0;
+
+    'minimization: loop {
+        for request_index in 0..current.0.len() {
+            let Some(candidate) = without_request(&current, request_index) else {
+                continue;
+            };
+
+            candidate_replays += 1;
+            let observation = match replay(&candidate).with_context(|| {
+                format!("Replaying candidate after removing request {request_index}")
+            }) {
+                Ok(observation) => observation,
+                Err(error) => {
+                    return failed(
+                        original_request_count,
+                        candidate_replays,
+                        format!("{error:#}"),
+                    );
+                }
+            };
+
+            if let ReplayOutcome::Crash(observation) = observation
+                && observation.identity.cluster_key() == *expected_cluster_key
+            {
+                current = candidate;
+                current_crashing_request_index = observation.crashing_request_index;
+                continue 'minimization;
+            }
+        }
+        break;
+    }
+
+    let minimized_request_count = current.0.len();
+    let removed_request_count = original_request_count.saturating_sub(minimized_request_count);
+    let status = if removed_request_count > 0 {
+        MinimizationStatus::Minimized
+    } else {
+        MinimizationStatus::Unchanged
+    };
+
+    MinimizationResult {
+        input: (removed_request_count > 0).then_some(current),
+        crashing_request_index: (removed_request_count > 0)
+            .then_some(current_crashing_request_index),
+        report: MinimizationReport {
+            status,
+            original_request_count,
+            minimized_request_count,
+            candidate_replays,
+            removed_request_count,
+            failure_reason: None,
+        },
+    }
+}
+
+pub fn failed(
+    original_request_count: usize,
+    candidate_replays: usize,
+    failure_reason: String,
+) -> MinimizationResult {
+    MinimizationResult {
+        input: None,
+        crashing_request_index: None,
+        report: MinimizationReport {
+            status: MinimizationStatus::Failed,
+            original_request_count,
+            minimized_request_count: original_request_count,
+            candidate_replays,
+            removed_request_count: 0,
+            failure_reason: Some(failure_reason),
+        },
+    }
+}
+
+fn without_request(input: &OpenApiInput, request_index: usize) -> Option<OpenApiInput> {
+    if input.0.len() <= 1 || request_index >= input.0.len() {
+        return None;
+    }
+    if input.0.iter().enumerate().any(|(index, request)| {
+        index != request_index && request_references_index(request, request_index)
+    }) {
+        return None;
+    }
+
+    let mut candidate = input.clone();
+    candidate.0.remove(request_index);
+    for request in &mut candidate.0 {
+        rewrite_request_references_after_removal(request, request_index);
+    }
+    Some(candidate)
+}
+
+fn request_references_index(request: &OpenApiRequest, request_index: usize) -> bool {
+    request
+        .parameters
+        .values()
+        .any(|parameter| parameter_references_index(parameter, request_index))
+        || request
+            .body
+            .contents()
+            .is_some_and(|body| parameter_references_index(body, request_index))
+}
+
+fn parameter_references_index(parameter: &ParameterContents, request_index: usize) -> bool {
+    match parameter {
+        ParameterContents::Object(values) => values
+            .values()
+            .any(|value| parameter_references_index(value, request_index)),
+        ParameterContents::Array(values) => values
+            .iter()
+            .any(|value| parameter_references_index(value, request_index)),
+        ParameterContents::OReference(reference) => reference.request_index == request_index,
+        ParameterContents::IReference(reference) => reference.request_index == request_index,
+        ParameterContents::LeafValue(_) | ParameterContents::Bytes(_) => false,
+    }
+}
+
+fn rewrite_request_references_after_removal(
+    request: &mut OpenApiRequest,
+    removed_request_index: usize,
+) {
+    for parameter in request.parameters.values_mut() {
+        rewrite_parameter_references_after_removal(parameter, removed_request_index);
+    }
+    if let Some(body) = request.body.contents_mut() {
+        rewrite_parameter_references_after_removal(body, removed_request_index);
+    }
+}
+
+fn rewrite_parameter_references_after_removal(
+    parameter: &mut ParameterContents,
+    removed_request_index: usize,
+) {
+    match parameter {
+        ParameterContents::Object(values) => {
+            for value in values.values_mut() {
+                rewrite_parameter_references_after_removal(value, removed_request_index);
+            }
+        }
+        ParameterContents::Array(values) => {
+            for value in values {
+                rewrite_parameter_references_after_removal(value, removed_request_index);
+            }
+        }
+        ParameterContents::OReference(reference) => {
+            if reference.request_index > removed_request_index {
+                reference.request_index -= 1;
+            }
+        }
+        ParameterContents::IReference(reference) => {
+            if reference.request_index > removed_request_index {
+                reference.request_index -= 1;
+            }
+        }
+        ParameterContents::LeafValue(_) | ParameterContents::Bytes(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        crash_dedup::{
+            identity::{CrashIdentity, CrashKind, ObservedExitKind, ResponseClass},
+            replay::ObservedCrash,
+        },
+        input::Method,
+    };
+
+    fn request(path: &str) -> OpenApiRequest {
+        OpenApiRequest {
+            method: Method::Get,
+            path: path.into(),
+            body: Body::Empty,
+            parameters: Default::default(),
+        }
+    }
+
+    fn observed_crash() -> ObservedCrash {
+        ObservedCrash {
+            identity: CrashIdentity {
+                exit_kind: ObservedExitKind::Crash,
+                crash_kind: CrashKind::Http5xx,
+                http_status: Some(500),
+                validation_error_discriminant: None,
+                endpoint: Some(String::from("GET /crash")),
+                response_class: ResponseClass::Json,
+            },
+            crashing_request_index: 1,
+        }
+    }
+
+    #[test]
+    fn minimization_removes_unnecessary_request() {
+        let crash = observed_crash();
+        let cluster_key = crash.identity.cluster_key();
+        let input = OpenApiInput(vec![request("/setup"), request("/crash")]);
+        let mut replay_count = 0;
+
+        let result = minimize_with(input, &cluster_key, |_| {
+            replay_count += 1;
+            Ok(ReplayOutcome::Crash(crash.clone()))
+        });
+
+        assert_eq!(result.report.status, MinimizationStatus::Minimized);
+        assert_eq!(result.report.removed_request_count, 1);
+        assert_eq!(result.report.minimized_request_count, 1);
+    }
+
+    #[test]
+    fn stopped_candidate_does_not_preserve_crash() {
+        let crash = observed_crash();
+        let cluster_key = crash.identity.cluster_key();
+        let input = OpenApiInput(vec![request("/setup"), request("/crash")]);
+        let mut replay_count = 0;
+
+        let result = minimize_with(input, &cluster_key, |_| {
+            replay_count += 1;
+            if replay_count == 1 {
+                Ok(ReplayOutcome::Crash(crash.clone()))
+            } else {
+                Ok(ReplayOutcome::Stopped(String::from(
+                    "missing backreference",
+                )))
+            }
+        });
+
+        assert_eq!(result.report.status, MinimizationStatus::Unchanged);
+        assert_eq!(result.report.removed_request_count, 0);
+        assert_eq!(result.report.candidate_replays, 2);
+    }
+}

--- a/src/crash_dedup/minimizer.rs
+++ b/src/crash_dedup/minimizer.rs
@@ -23,6 +23,8 @@ pub struct MinimizationReport {
     pub removed_request_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
 }
 
 pub struct MinimizationResult {
@@ -122,6 +124,7 @@ where
             candidate_replays,
             removed_request_count,
             failure_reason: None,
+            output: None,
         },
     }
 }
@@ -141,6 +144,7 @@ pub fn failed(
             candidate_replays,
             removed_request_count: 0,
             failure_reason: Some(failure_reason),
+            output: None,
         },
     }
 }

--- a/src/crash_dedup/minimizer.rs
+++ b/src/crash_dedup/minimizer.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use crate::{
     crash_dedup::{identity::CrashClusterKey, replay::ReplayOutcome},
-    input::{Body, OpenApiInput, OpenApiRequest, ParameterContents},
+    input::{OpenApiInput, OpenApiRequest, ParameterContents},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -241,7 +241,7 @@ mod tests {
             identity::{CrashIdentity, CrashKind, ObservedExitKind, ResponseClass},
             replay::ObservedCrash,
         },
-        input::Method,
+        input::{Body, Method},
     };
 
     fn request(path: &str) -> OpenApiRequest {

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result, anyhow};
 use libafl::inputs::Input;
 use serde::Serialize;
 use walkdir::WalkDir;
+use serde_json;
 
 use crate::{
     configuration::Configuration,
@@ -51,16 +52,42 @@ pub fn dedup_crashes(crash_directory: &Path, output_directory: &Path) -> Result<
         log_progress(index + 1, crash_files.len(), clusters.len(), non_reproducible.len(), skipped.len());
     }
 
-    log::info!(
-        "Dedup complete: {} crash files, {} unique clusters, {} non-reproducible, {} skipped. Output: {}",
-        crash_files.len(),
-        clusters.len(),
-        non_reproducible.len(),
-        skipped.len(),
-        output_directory.display()
-    );
+    copy_unique_representatives(&output_directory, &mut clusters)?;
+
+    let clusters: Vec<_> = clusters.into_values().collect();
+    let report = DedupReport {
+        summary: DedupSummary {
+            total_files: crash_files.len(),
+            reproduced: clusters.iter().map(|c| c.member_count).sum(),
+            unique_clusters: clusters.len(),
+            non_reproducible: non_reproducible.len(),
+            skipped: skipped.len(),
+        },
+        clusters,
+        non_reproducible,
+        skipped,
+    };
+    write_report(&output_directory, &report)?;
+    log_summary(&report.summary, &output_directory);
 
     Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct DedupReport {
+    summary: DedupSummary,
+    clusters: Vec<CrashCluster>,
+    non_reproducible: Vec<CrashFileResult>,
+    skipped: Vec<CrashFileResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct DedupSummary {
+    total_files: usize,
+    reproduced: usize,
+    unique_clusters: usize,
+    non_reproducible: usize,
+    skipped: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -175,6 +202,59 @@ fn is_crash_input_file(path: &Path) -> bool {
         return false;
     };
     !file_name.starts_with('.') && !file_name.ends_with(".metadata")
+}
+
+fn copy_unique_representatives(
+    output_directory: &Path,
+    clusters: &mut BTreeMap<CrashClusterKey, CrashCluster>,
+) -> Result<()> {
+    let unique_directory = output_directory.join("unique");
+    fs::create_dir_all(&unique_directory).with_context(|| {
+        format!("Creating unique crash directory {}", unique_directory.display())
+    })?;
+
+    for (index, cluster) in clusters.values_mut().enumerate() {
+        let destination = unique_directory.join(unique_file_name(index, &cluster.representative_source));
+        fs::copy(&cluster.representative_source, &destination).with_context(|| {
+            format!(
+                "Copying representative {} to {}",
+                cluster.representative_source.display(),
+                destination.display()
+            )
+        })?;
+        cluster.representative = relative_string(output_directory, &destination);
+    }
+
+    Ok(())
+}
+
+fn unique_file_name(index: usize, source_path: &Path) -> String {
+    let file_name = source_path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("crash");
+    format!("{index:06}_{file_name}")
+}
+
+fn write_report(output_directory: &Path, report: &DedupReport) -> Result<()> {
+    let report_path = output_directory.join("clusters.json");
+    let file = fs::File::create(&report_path)
+        .with_context(|| format!("Creating dedup report {}", report_path.display()))?;
+    serde_json::to_writer_pretty(file, report)
+        .with_context(|| format!("Writing dedup report {}", report_path.display()))?;
+    Ok(())
+}
+
+fn log_summary(summary: &DedupSummary, output_directory: &Path) {
+    log::info!(
+        "Dedup complete: {} crash files, {} reproduced, {} unique clusters, {} non-reproducible, {} skipped. Output: {}",
+        summary.total_files,
+        summary.reproduced,
+        summary.unique_clusters,
+        summary.non_reproducible,
+        summary.skipped,
+        output_directory.display()
+    );
 }
 
 enum FileOutcome {

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -14,9 +14,10 @@ use serde::Serialize;
 use walkdir::WalkDir;
 
 use crate::{
-    configuration::Configuration,
+    configuration::{Configuration, MinimizationMode},
     crash_dedup::{
         identity::{CrashClusterKey, CrashIdentity},
+        minimizer::{MinimizationReport, MinimizationResult, failed, minimize_with},
         replay::{ObservedCrash, ReplayOutcome, replay_input},
     },
     input::OpenApiInput,
@@ -25,7 +26,11 @@ use crate::{
 
 const DEDUP_PROGRESS_INTERVAL: usize = 100;
 
-pub fn dedup_crashes(crash_directory: &Path, output_directory: &Path) -> Result<()> {
+pub fn dedup_crashes(
+    crash_directory: &Path,
+    output_directory: &Path,
+    minimize: Option<MinimizationMode>,
+) -> Result<()> {
     let output_directory = prepare_output_directory(crash_directory, output_directory)?;
     let config = Configuration::get().map_err(anyhow::Error::msg)?;
     crate::setup_logging(config);
@@ -64,7 +69,7 @@ pub fn dedup_crashes(crash_directory: &Path, output_directory: &Path) -> Result<
         );
     }
 
-    copy_unique_representatives(&output_directory, &mut clusters)?;
+    write_cluster_outputs(&output_directory, &mut clusters, &api, config, minimize)?;
 
     let clusters: Vec<_> = clusters.into_values().collect();
     let report = DedupReport {
@@ -114,6 +119,14 @@ struct CrashCluster {
     member_count: usize,
     representative_crashing_request_index: usize,
     identity: SerializableCrashIdentity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minimization: Option<ClusterMinimizationReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct ClusterMinimizationReport {
+    mode: MinimizationMode,
+    files: BTreeMap<String, MinimizationReport>,
 }
 
 #[derive(Debug, Serialize)]
@@ -241,6 +254,88 @@ fn copy_unique_representatives(
     Ok(())
 }
 
+fn write_cluster_outputs(
+    output_directory: &Path,
+    clusters: &mut BTreeMap<CrashClusterKey, CrashCluster>,
+    api: &Spec,
+    config: &Configuration,
+    mode: Option<MinimizationMode>,
+) -> Result<()> {
+    let Some(mode) = mode else {
+        return copy_unique_representatives(output_directory, clusters);
+    };
+
+    let unique_directory = output_directory.join("unique");
+    fs::create_dir_all(&unique_directory).with_context(|| {
+        format!(
+            "Creating unique crash directory {}",
+            unique_directory.display()
+        )
+    })?;
+
+    let total = clusters.len();
+    log::info!("Starting crash minimization ({mode:?}): {total} clusters");
+
+    for (index, (cluster_key, cluster)) in clusters.iter_mut().enumerate() {
+        let destination =
+            unique_directory.join(unique_file_name(index, &cluster.representative_source));
+        let representative_member = cluster.representative.clone();
+
+        let mut result = minimize_source(&cluster.representative_source, cluster_key, api, config);
+        write_minimization_output(&cluster.representative_source, &destination, &mut result)?;
+        if let Some(idx) = result.crashing_request_index {
+            cluster.representative_crashing_request_index = idx;
+        }
+        result.report.output = Some(relative_string(output_directory, &destination));
+        cluster.representative = relative_string(output_directory, &destination);
+
+        let mut files = BTreeMap::new();
+        files.insert(representative_member, result.report);
+        cluster.minimization = Some(ClusterMinimizationReport { mode, files });
+
+        log::info!(
+            "Crash minimization progress: {}/{total} clusters processed",
+            index + 1
+        );
+    }
+
+    Ok(())
+}
+
+fn minimize_source(
+    source: &Path,
+    cluster_key: &CrashClusterKey,
+    api: &Spec,
+    config: &Configuration,
+) -> MinimizationResult {
+    let input = match OpenApiInput::from_file(source) {
+        Ok(input) => input,
+        Err(error) => return failed(0, 0, format!("Could not read crash input: {error}")),
+    };
+    minimize_with(input, cluster_key, |candidate| {
+        replay_input(candidate, api, config)
+    })
+}
+
+fn write_minimization_output(
+    source: &Path,
+    destination: &Path,
+    result: &mut MinimizationResult,
+) -> Result<()> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Creating directory {}", parent.display()))?;
+    }
+    if let Some(input) = result.input.take() {
+        input.to_file(destination).map_err(anyhow::Error::msg)?;
+    } else {
+        fs::copy(source, destination).with_context(|| {
+            format!("Copying {} to {}", source.display(), destination.display())
+        })?;
+    }
+    Ok(())
+}
+
 fn unique_file_name(index: usize, source_path: &Path) -> String {
     let file_name = source_path
         .file_name()
@@ -336,6 +431,7 @@ fn add_to_clusters(
                     member_count: 1,
                     representative_crashing_request_index: observed_crash.crashing_request_index,
                     identity: SerializableCrashIdentity::from(&observed_crash.identity),
+                    minimization: None,
                 },
             );
         }

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -209,7 +209,7 @@ struct CrashFileResult {
 fn prepare_output_directory(crash_directory: &Path, output_directory: &Path) -> Result<PathBuf> {
     ensure_crash_directory(crash_directory)?;
 
-    fs::create_dir_all(&output_directory)?;
+    fs::create_dir_all(output_directory)?;
 
     let crash_directory = std::fs::canonicalize(crash_directory)?;
     let output_directory = std::fs::canonicalize(output_directory)?;

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -11,7 +11,6 @@ use anyhow::{Context, Result, anyhow};
 use libafl::inputs::Input;
 use serde::Serialize;
 use walkdir::WalkDir;
-use serde_json;
 
 use crate::{
     configuration::Configuration,
@@ -43,13 +42,25 @@ pub fn dedup_crashes(crash_directory: &Path, output_directory: &Path) -> Result<
                 add_to_clusters(&mut clusters, crash_file, source_path, size, crash);
             }
             FileOutcome::NonReproducible(reason) => {
-                non_reproducible.push(CrashFileResult { path: source_path, reason });
+                non_reproducible.push(CrashFileResult {
+                    path: source_path,
+                    reason,
+                });
             }
             FileOutcome::Skipped(reason) => {
-                skipped.push(CrashFileResult { path: source_path, reason });
+                skipped.push(CrashFileResult {
+                    path: source_path,
+                    reason,
+                });
             }
         }
-        log_progress(index + 1, crash_files.len(), clusters.len(), non_reproducible.len(), skipped.len());
+        log_progress(
+            index + 1,
+            crash_files.len(),
+            clusters.len(),
+            non_reproducible.len(),
+            skipped.len(),
+        );
     }
 
     copy_unique_representatives(&output_directory, &mut clusters)?;
@@ -136,10 +147,7 @@ struct CrashFileResult {
     reason: String,
 }
 
-fn prepare_output_directory(
-    crash_directory: &Path,
-    output_directory: &Path,
-) -> Result<PathBuf> {
+fn prepare_output_directory(crash_directory: &Path, output_directory: &Path) -> Result<PathBuf> {
     ensure_crash_directory(crash_directory)?;
 
     let crash_directory = std::path::absolute(crash_directory)?;
@@ -210,11 +218,15 @@ fn copy_unique_representatives(
 ) -> Result<()> {
     let unique_directory = output_directory.join("unique");
     fs::create_dir_all(&unique_directory).with_context(|| {
-        format!("Creating unique crash directory {}", unique_directory.display())
+        format!(
+            "Creating unique crash directory {}",
+            unique_directory.display()
+        )
     })?;
 
     for (index, cluster) in clusters.values_mut().enumerate() {
-        let destination = unique_directory.join(unique_file_name(index, &cluster.representative_source));
+        let destination =
+            unique_directory.join(unique_file_name(index, &cluster.representative_source));
         fs::copy(&cluster.representative_source, &destination).with_context(|| {
             format!(
                 "Copying representative {} to {}",
@@ -271,13 +283,22 @@ fn process_crash_file(crash_file: &Path, api: &Spec, config: &Configuration) -> 
 
     let crash = match replay_input(&input, api, config) {
         Ok(ReplayOutcome::Crash(crash)) => crash,
-        Ok(ReplayOutcome::Completed) => return FileOutcome::NonReproducible(String::from("Replay did not reproduce a crash")),
-        Ok(ReplayOutcome::Stopped(reason)) => return FileOutcome::NonReproducible(format!("Replay stopped: {reason}")),
-        Err(error) => return FileOutcome::Skipped(format!("Could not replay crash input: {error}")),
+        Ok(ReplayOutcome::Completed) => {
+            return FileOutcome::NonReproducible(String::from("Replay did not reproduce a crash"));
+        }
+        Ok(ReplayOutcome::Stopped(reason)) => {
+            return FileOutcome::NonReproducible(format!("Replay stopped: {reason}"));
+        }
+        Err(error) => {
+            return FileOutcome::Skipped(format!("Could not replay crash input: {error}"));
+        }
     };
 
     match fs::metadata(crash_file) {
-        Ok(metadata) => FileOutcome::Clustered { crash, size: metadata.len() },
+        Ok(metadata) => FileOutcome::Clustered {
+            crash,
+            size: metadata.len(),
+        },
         Err(error) => FileOutcome::Skipped(format!("Could not read crash input metadata: {error}")),
     }
 }
@@ -386,10 +407,28 @@ mod tests {
         let mut clusters = BTreeMap::new();
 
         // large first, then a smaller duplicate — representative should flip to smaller
-        add_to_clusters(&mut clusters, Path::new("large"), String::from("large"), 100, make_crash_with_index("GET /items", 2));
-        add_to_clusters(&mut clusters, Path::new("small"), String::from("small"), 10, make_crash_with_index("GET /items", 1));
+        add_to_clusters(
+            &mut clusters,
+            Path::new("large"),
+            String::from("large"),
+            100,
+            make_crash_with_index("GET /items", 2),
+        );
+        add_to_clusters(
+            &mut clusters,
+            Path::new("small"),
+            String::from("small"),
+            10,
+            make_crash_with_index("GET /items", 1),
+        );
         // different endpoint → second cluster
-        add_to_clusters(&mut clusters, Path::new("other"), String::from("other"), 10, make_crash("POST /items"));
+        add_to_clusters(
+            &mut clusters,
+            Path::new("other"),
+            String::from("other"),
+            10,
+            make_crash("POST /items"),
+        );
 
         assert_eq!(clusters.len(), 2);
         let get_cluster = clusters.values().next().unwrap();
@@ -405,7 +444,10 @@ mod tests {
         fs::create_dir(&crashes)?;
 
         let err = prepare_output_directory(&crashes, &crashes.join("out")).unwrap_err();
-        assert!(err.to_string().contains("must not be inside or equal to crash directory"));
+        assert!(
+            err.to_string()
+                .contains("must not be inside or equal to crash directory")
+        );
         Ok(())
     }
 }

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -1,2 +1,19 @@
 mod identity;
 pub mod replay;
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::configuration::Configuration;
+
+pub fn dedup_crashes(crash_directory: &Path, output_directory: &Path) -> Result<()> {
+    let config = Configuration::get().map_err(anyhow::Error::msg)?;
+    crate::setup_logging(config);
+
+    bail!(
+        "Crash deduplication not yet implemented (input: {}, output: {})",
+        crash_directory.display(),
+        output_directory.display()
+    )
+}

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -1,19 +1,331 @@
 mod identity;
 pub mod replay;
 
-use std::path::Path;
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
+use libafl::inputs::Input;
+use serde::Serialize;
+use walkdir::WalkDir;
 
-use crate::configuration::Configuration;
+use crate::{
+    configuration::Configuration,
+    crash_dedup::{
+        identity::{CrashClusterKey, CrashIdentity},
+        replay::{ObservedCrash, ReplayOutcome, replay_input},
+    },
+    input::OpenApiInput,
+    openapi::{parse_api_spec, spec::Spec},
+};
+
+const DEDUP_PROGRESS_INTERVAL: usize = 100;
 
 pub fn dedup_crashes(crash_directory: &Path, output_directory: &Path) -> Result<()> {
+    let output_directory = prepare_output_directory(crash_directory, output_directory)?;
     let config = Configuration::get().map_err(anyhow::Error::msg)?;
     crate::setup_logging(config);
 
-    bail!(
-        "Crash deduplication not yet implemented (input: {}, output: {})",
-        crash_directory.display(),
+    let api = parse_api_spec(config)?;
+    let crash_files = get_crash_files(crash_directory)?;
+    let mut clusters: BTreeMap<CrashClusterKey, CrashCluster> = BTreeMap::new();
+    let mut non_reproducible = Vec::new();
+    let mut skipped = Vec::new();
+
+    for (index, crash_file) in crash_files.iter().enumerate() {
+        let source_path = relative_string(crash_directory, crash_file);
+        match process_crash_file(crash_file, &api, config) {
+            FileOutcome::Clustered { crash, size } => {
+                add_to_clusters(&mut clusters, crash_file, source_path, size, crash);
+            }
+            FileOutcome::NonReproducible(reason) => {
+                non_reproducible.push(CrashFileResult { path: source_path, reason });
+            }
+            FileOutcome::Skipped(reason) => {
+                skipped.push(CrashFileResult { path: source_path, reason });
+            }
+        }
+        log_progress(index + 1, crash_files.len(), clusters.len(), non_reproducible.len(), skipped.len());
+    }
+
+    log::info!(
+        "Dedup complete: {} crash files, {} unique clusters, {} non-reproducible, {} skipped. Output: {}",
+        crash_files.len(),
+        clusters.len(),
+        non_reproducible.len(),
+        skipped.len(),
         output_directory.display()
-    )
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct CrashCluster {
+    key: String,
+    #[serde(skip)]
+    representative_source: PathBuf,
+    #[serde(skip)]
+    representative_size: u64,
+    representative: String,
+    members: Vec<String>,
+    member_count: usize,
+    representative_crashing_request_index: usize,
+    identity: SerializableCrashIdentity,
+}
+
+#[derive(Debug, Serialize)]
+struct SerializableCrashIdentity {
+    exit_kind: String,
+    crash_kind: String,
+    http_status: Option<u16>,
+    validation_error_discriminant: Option<String>,
+    endpoint: Option<String>,
+    response_class: String,
+}
+
+impl From<&CrashIdentity> for SerializableCrashIdentity {
+    fn from(identity: &CrashIdentity) -> Self {
+        Self {
+            exit_kind: identity.exit_kind.to_string(),
+            crash_kind: identity.crash_kind.to_string(),
+            http_status: identity.http_status,
+            validation_error_discriminant: identity
+                .validation_error_discriminant
+                .as_ref()
+                .map(|d| format!("{d:?}")),
+            endpoint: identity.endpoint.clone(),
+            response_class: identity.response_class.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CrashFileResult {
+    path: String,
+    reason: String,
+}
+
+fn prepare_output_directory(
+    crash_directory: &Path,
+    output_directory: &Path,
+) -> Result<PathBuf> {
+    ensure_crash_directory(crash_directory)?;
+
+    let crash_directory = std::path::absolute(crash_directory)?;
+    let output_directory = std::path::absolute(output_directory)?;
+    if output_directory.starts_with(&crash_directory) {
+        return Err(anyhow!(
+            "Output directory {} must not be inside or equal to crash directory {} because crash collection is recursive",
+            output_directory.display(),
+            crash_directory.display()
+        ));
+    }
+    if output_directory.exists() && !output_directory.is_dir() {
+        return Err(anyhow!(
+            "Output path {} exists but is not a directory",
+            output_directory.display()
+        ));
+    }
+
+    fs::create_dir_all(&output_directory)?;
+    Ok(output_directory)
+}
+
+fn get_crash_files(crash_directory: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(crash_directory).min_depth(1) {
+        let entry = entry.with_context(|| {
+            format!(
+                "Walking crash directory {}",
+                crash_directory.to_string_lossy()
+            )
+        })?;
+
+        if entry.file_type().is_file() && is_crash_input_file(entry.path()) {
+            files.push(entry.path().to_path_buf());
+        }
+    }
+
+    files.sort();
+    Ok(files)
+}
+
+fn ensure_crash_directory(crash_directory: &Path) -> Result<()> {
+    if !crash_directory.exists() {
+        return Err(anyhow!(
+            "Crash directory {} does not exist",
+            crash_directory.display()
+        ));
+    }
+    if !crash_directory.is_dir() {
+        return Err(anyhow!(
+            "Crash path {} is not a directory",
+            crash_directory.display()
+        ));
+    }
+    Ok(())
+}
+
+fn is_crash_input_file(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|f| f.to_str()) else {
+        return false;
+    };
+    !file_name.starts_with('.') && !file_name.ends_with(".metadata")
+}
+
+enum FileOutcome {
+    Clustered { crash: ObservedCrash, size: u64 },
+    NonReproducible(String),
+    Skipped(String),
+}
+
+fn process_crash_file(crash_file: &Path, api: &Spec, config: &Configuration) -> FileOutcome {
+    let input = match OpenApiInput::from_file(crash_file) {
+        Ok(input) => input,
+        Err(error) => return FileOutcome::Skipped(format!("Could not read crash input: {error}")),
+    };
+
+    let crash = match replay_input(&input, api, config) {
+        Ok(ReplayOutcome::Crash(crash)) => crash,
+        Ok(ReplayOutcome::Completed) => return FileOutcome::NonReproducible(String::from("Replay did not reproduce a crash")),
+        Ok(ReplayOutcome::Stopped(reason)) => return FileOutcome::NonReproducible(format!("Replay stopped: {reason}")),
+        Err(error) => return FileOutcome::Skipped(format!("Could not replay crash input: {error}")),
+    };
+
+    match fs::metadata(crash_file) {
+        Ok(metadata) => FileOutcome::Clustered { crash, size: metadata.len() },
+        Err(error) => FileOutcome::Skipped(format!("Could not read crash input metadata: {error}")),
+    }
+}
+
+fn add_to_clusters(
+    clusters: &mut BTreeMap<CrashClusterKey, CrashCluster>,
+    source_file: &Path,
+    source_path: String,
+    source_size: u64,
+    observed_crash: ObservedCrash,
+) {
+    let key = observed_crash.identity.cluster_key();
+    match clusters.get_mut(&key) {
+        Some(cluster) => {
+            cluster.members.push(source_path.clone());
+            cluster.member_count = cluster.members.len();
+            if source_size < cluster.representative_size {
+                cluster.representative_source = source_file.to_path_buf();
+                cluster.representative_size = source_size;
+                cluster.representative = source_path;
+                cluster.representative_crashing_request_index =
+                    observed_crash.crashing_request_index;
+            }
+        }
+        None => {
+            clusters.insert(
+                key.clone(),
+                CrashCluster {
+                    key: key.to_string(),
+                    representative_source: source_file.to_path_buf(),
+                    representative_size: source_size,
+                    representative: source_path.clone(),
+                    members: vec![source_path],
+                    member_count: 1,
+                    representative_crashing_request_index: observed_crash.crashing_request_index,
+                    identity: SerializableCrashIdentity::from(&observed_crash.identity),
+                },
+            );
+        }
+    }
+}
+
+fn log_progress(
+    processed: usize,
+    total: usize,
+    unique_clusters: usize,
+    non_reproducible: usize,
+    skipped: usize,
+) {
+    if processed < total && processed.is_multiple_of(DEDUP_PROGRESS_INTERVAL) {
+        log::info!(
+            "Dedup progress: {processed}/{total} files processed, {unique_clusters} unique clusters, {non_reproducible} non-reproducible, {skipped} skipped"
+        );
+    }
+}
+
+fn relative_string(base: &Path, path: &Path) -> String {
+    path.strip_prefix(base)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::crash_dedup::identity::{CrashKind, ObservedExitKind, ResponseClass};
+
+    fn make_crash(endpoint: &str) -> ObservedCrash {
+        make_crash_with_index(endpoint, 0)
+    }
+
+    fn make_crash_with_index(endpoint: &str, crashing_request_index: usize) -> ObservedCrash {
+        ObservedCrash {
+            identity: CrashIdentity {
+                exit_kind: ObservedExitKind::Crash,
+                crash_kind: CrashKind::Http5xx,
+                http_status: Some(500),
+                validation_error_discriminant: None,
+                endpoint: Some(endpoint.to_string()),
+                response_class: ResponseClass::Json,
+            },
+            crashing_request_index,
+        }
+    }
+
+    #[test]
+    fn get_crash_files_ignores_metadata_and_hidden_files() -> Result<()> {
+        let dir = TempDir::new()?;
+        fs::write(dir.path().join("crash-a"), b"")?;
+        fs::write(dir.path().join("crash-b.metadata"), b"")?;
+        fs::write(dir.path().join(".hidden"), b"")?;
+
+        let files = get_crash_files(dir.path())?;
+
+        assert_eq!(files, vec![dir.path().join("crash-a")]);
+        Ok(())
+    }
+
+    #[test]
+    fn add_to_clusters_groups_deduplicates_and_prefers_smaller_representative() {
+        let mut clusters = BTreeMap::new();
+
+        // large first, then a smaller duplicate — representative should flip to smaller
+        add_to_clusters(&mut clusters, Path::new("large"), String::from("large"), 100, make_crash_with_index("GET /items", 2));
+        add_to_clusters(&mut clusters, Path::new("small"), String::from("small"), 10, make_crash_with_index("GET /items", 1));
+        // different endpoint → second cluster
+        add_to_clusters(&mut clusters, Path::new("other"), String::from("other"), 10, make_crash("POST /items"));
+
+        assert_eq!(clusters.len(), 2);
+        let get_cluster = clusters.values().next().unwrap();
+        assert_eq!(get_cluster.member_count, 2);
+        assert_eq!(get_cluster.representative, "small");
+        assert_eq!(get_cluster.representative_crashing_request_index, 1);
+    }
+
+    #[test]
+    fn prepare_output_directory_rejects_nested_output() -> Result<()> {
+        let dir = TempDir::new()?;
+        let crashes = dir.path().join("crashes");
+        fs::create_dir(&crashes)?;
+
+        let err = prepare_output_directory(&crashes, &crashes.join("out")).unwrap_err();
+        assert!(err.to_string().contains("must not be inside or equal to crash directory"));
+        Ok(())
+    }
 }

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -1,3 +1,20 @@
+//! Crash deduplication and optional minimization pipeline.
+//!
+//! This module powers `wuppiefuzz dedup`.
+//! High-level flow:
+//! 1. Discover crash files in input directory.
+//! 2. Replay each file and derive a crash identity key.
+//! 3. Group files by key into clusters and pick smallest representative.
+//! 4. Write one representative per cluster to `output/unique`.
+//! 5. Optionally minimize representatives (or all members) while preserving cluster key.
+//! 6. Emit `clusters.json` with summary counts and per-cluster details.
+//!
+//! Where to find things:
+//! - [`dedup_crashes`] orchestrates end-to-end command behavior.
+//! - `identity` defines crash identity dimensions and cluster keys.
+//! - `replay` replays an input and reports observed crash identity.
+//! - `minimizer` performs delta-debugging minimization.
+
 mod identity;
 pub mod minimizer;
 pub mod replay;
@@ -28,6 +45,12 @@ use crate::{
 
 const DEDUP_PROGRESS_INTERVAL: usize = 100;
 
+/// Deduplicate crash files by replayed crash identity and optionally minimize outputs.
+///
+/// Preconditions:
+/// - `crash_directory` must exist and be a directory.
+/// - `output_directory` must not be equal to, or nested under, `crash_directory`.
+/// - Global configuration must already be loadable via [`Configuration::get`].
 pub fn dedup_crashes(
     crash_directory: &Path,
     output_directory: &Path,
@@ -180,6 +203,9 @@ struct CrashFileResult {
     reason: String,
 }
 
+/// Validate crash/output directories and return normalized absolute output path.
+///
+/// Rejects output paths inside crash directory to avoid recursively reprocessing generated output.
 fn prepare_output_directory(crash_directory: &Path, output_directory: &Path) -> Result<PathBuf> {
     ensure_crash_directory(crash_directory)?;
 
@@ -203,6 +229,9 @@ fn prepare_output_directory(crash_directory: &Path, output_directory: &Path) -> 
     Ok(output_directory)
 }
 
+/// Recursively collect candidate crash input files from `crash_directory`.
+///
+/// Hidden files and `.metadata` sidecars are skipped.
 fn get_crash_files(crash_directory: &Path) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     for entry in WalkDir::new(crash_directory).min_depth(1) {
@@ -222,6 +251,7 @@ fn get_crash_files(crash_directory: &Path) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
+/// Validate that crash input root exists and is a directory.
 fn ensure_crash_directory(crash_directory: &Path) -> Result<()> {
     if !crash_directory.exists() {
         return Err(anyhow!(
@@ -238,6 +268,9 @@ fn ensure_crash_directory(crash_directory: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Return `true` for replayable crash input files.
+///
+/// Current filter excludes hidden files and `.metadata` files.
 fn is_crash_input_file(path: &Path) -> bool {
     let Some(file_name) = path.file_name().and_then(|f| f.to_str()) else {
         return false;
@@ -245,6 +278,9 @@ fn is_crash_input_file(path: &Path) -> bool {
     !file_name.starts_with('.') && !file_name.ends_with(".metadata")
 }
 
+/// Copy one representative input per cluster to `output_directory/unique`.
+///
+/// Updates each cluster's `representative` field to its output-relative destination path.
 fn copy_unique_representatives(
     output_directory: &Path,
     clusters: &mut BTreeMap<CrashClusterKey, CrashCluster>,
@@ -273,6 +309,10 @@ fn copy_unique_representatives(
     Ok(())
 }
 
+/// Write per-cluster outputs according to minimization mode.
+///
+/// With no mode, this copies representatives only. With minimization enabled, it writes
+/// minimized files and records per-file minimization reports.
 fn write_cluster_outputs(
     crash_directory: &Path,
     output_directory: &Path,
@@ -362,6 +402,9 @@ fn write_cluster_outputs(
     Ok(())
 }
 
+/// Load one crash input file and run delta-debugging minimization against expected cluster key.
+///
+/// If input cannot be read, returns a failed minimization result instead of bubbling error.
 fn minimize_source(
     source: &Path,
     cluster_key: &CrashClusterKey,
@@ -377,6 +420,9 @@ fn minimize_source(
     })
 }
 
+/// Persist minimization output for one source file.
+///
+/// Writes minimized input when available; otherwise copies original source unchanged.
 fn write_minimization_output(
     source: &Path,
     destination: &Path,
@@ -396,6 +442,7 @@ fn write_minimization_output(
     Ok(())
 }
 
+/// Build deterministic output file name for unique representatives.
 fn unique_file_name(index: usize, source_path: &Path) -> String {
     let file_name = source_path
         .file_name()
@@ -404,6 +451,7 @@ fn unique_file_name(index: usize, source_path: &Path) -> String {
     format!("{index:06}_{file_name}")
 }
 
+/// Write final dedup report to `clusters.json` under output directory.
 fn write_report(output_directory: &Path, report: &DedupReport) -> Result<()> {
     let report_path = output_directory.join("clusters.json");
     let file = fs::File::create(&report_path)
@@ -413,6 +461,9 @@ fn write_report(output_directory: &Path, report: &DedupReport) -> Result<()> {
     Ok(())
 }
 
+/// Aggregate per-file minimization statuses into top-level summary counts.
+///
+/// Returns `None` when no minimization data exists.
 fn minimization_summary(clusters: &[CrashCluster]) -> Option<MinimizationSummary> {
     let mut reports = clusters
         .iter()
@@ -435,6 +486,7 @@ fn minimization_summary(clusters: &[CrashCluster]) -> Option<MinimizationSummary
     Some(summary)
 }
 
+/// Log end-of-run counts and optional minimization breakdown.
 fn log_summary(summary: &DedupSummary, output_directory: &Path) {
     log::info!(
         "Dedup complete: {} crash files, {} reproduced, {} unique clusters, {} non-reproducible, {} skipped. Output: {}",
@@ -461,6 +513,12 @@ enum FileOutcome {
     Skipped(String),
 }
 
+/// Replay one crash file and classify outcome for dedup accounting.
+///
+/// Returns:
+/// - `Clustered` when replay reproduces crash and metadata can be read.
+/// - `NonReproducible` when replay completes or stops without crash.
+/// - `Skipped` for unreadable inputs or replay/metadata errors.
 fn process_crash_file(crash_file: &Path, api: &Spec, config: &Configuration) -> FileOutcome {
     let input = match OpenApiInput::from_file(crash_file) {
         Ok(input) => input,
@@ -489,6 +547,9 @@ fn process_crash_file(crash_file: &Path, api: &Spec, config: &Configuration) -> 
     }
 }
 
+/// Insert crash into cluster map and update representative selection.
+///
+/// Smallest source file per key is kept as representative.
 fn add_to_clusters(
     clusters: &mut BTreeMap<CrashClusterKey, CrashCluster>,
     source_file: &Path,
@@ -528,6 +589,9 @@ fn add_to_clusters(
     }
 }
 
+/// Emit periodic progress logs while scanning crash files.
+///
+/// Logs every [`DEDUP_PROGRESS_INTERVAL`] files, excluding final summary.
 fn log_progress(
     processed: usize,
     total: usize,
@@ -542,6 +606,7 @@ fn log_progress(
     }
 }
 
+/// Convert `path` to slash-normalized string relative to `base` when possible.
 fn relative_string(base: &Path, path: &Path) -> String {
     path.strip_prefix(base)
         .unwrap_or(path)
@@ -608,7 +673,7 @@ mod tests {
             10,
             make_crash_with_index("GET /items", 1),
         );
-        // different endpoint → second cluster
+        // different endpoint -> second cluster
         add_to_clusters(
             &mut clusters,
             Path::new("other"),

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -209,8 +209,10 @@ struct CrashFileResult {
 fn prepare_output_directory(crash_directory: &Path, output_directory: &Path) -> Result<PathBuf> {
     ensure_crash_directory(crash_directory)?;
 
-    let crash_directory = std::path::absolute(crash_directory)?;
-    let output_directory = std::path::absolute(output_directory)?;
+    fs::create_dir_all(&output_directory)?;
+
+    let crash_directory = std::fs::canonicalize(crash_directory)?;
+    let output_directory = std::fs::canonicalize(output_directory)?;
     if output_directory.starts_with(&crash_directory) {
         return Err(anyhow!(
             "Output directory {} must not be inside or equal to crash directory {} because crash collection is recursive",
@@ -225,7 +227,6 @@ fn prepare_output_directory(crash_directory: &Path, output_directory: &Path) -> 
         ));
     }
 
-    fs::create_dir_all(&output_directory)?;
     Ok(output_directory)
 }
 

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -17,7 +17,9 @@ use crate::{
     configuration::{Configuration, MinimizationMode},
     crash_dedup::{
         identity::{CrashClusterKey, CrashIdentity},
-        minimizer::{MinimizationReport, MinimizationResult, failed, minimize_with},
+        minimizer::{
+            MinimizationReport, MinimizationResult, MinimizationStatus, failed, minimize_with,
+        },
         replay::{ObservedCrash, ReplayOutcome, replay_input},
     },
     input::OpenApiInput,
@@ -69,7 +71,14 @@ pub fn dedup_crashes(
         );
     }
 
-    write_cluster_outputs(&output_directory, &mut clusters, &api, config, minimize)?;
+    write_cluster_outputs(
+        crash_directory,
+        &output_directory,
+        &mut clusters,
+        &api,
+        config,
+        minimize,
+    )?;
 
     let clusters: Vec<_> = clusters.into_values().collect();
     let report = DedupReport {
@@ -79,6 +88,7 @@ pub fn dedup_crashes(
             unique_clusters: clusters.len(),
             non_reproducible: non_reproducible.len(),
             skipped: skipped.len(),
+            minimization: minimization_summary(&clusters),
         },
         clusters,
         non_reproducible,
@@ -105,6 +115,15 @@ struct DedupSummary {
     unique_clusters: usize,
     non_reproducible: usize,
     skipped: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minimization: Option<MinimizationSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct MinimizationSummary {
+    minimized: usize,
+    unchanged: usize,
+    failed: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -255,6 +274,7 @@ fn copy_unique_representatives(
 }
 
 fn write_cluster_outputs(
+    crash_directory: &Path,
     output_directory: &Path,
     clusters: &mut BTreeMap<CrashClusterKey, CrashCluster>,
     api: &Spec,
@@ -274,25 +294,65 @@ fn write_cluster_outputs(
     })?;
 
     let total = clusters.len();
+    let minimized_directory = output_directory.join("minimized");
     log::info!("Starting crash minimization ({mode:?}): {total} clusters");
 
     for (index, (cluster_key, cluster)) in clusters.iter_mut().enumerate() {
-        let destination =
+        let unique_destination =
             unique_directory.join(unique_file_name(index, &cluster.representative_source));
         let representative_member = cluster.representative.clone();
-
-        let mut result = minimize_source(&cluster.representative_source, cluster_key, api, config);
-        write_minimization_output(&cluster.representative_source, &destination, &mut result)?;
-        if let Some(idx) = result.crashing_request_index {
-            cluster.representative_crashing_request_index = idx;
-        }
-        result.report.output = Some(relative_string(output_directory, &destination));
-        cluster.representative = relative_string(output_directory, &destination);
-
         let mut files = BTreeMap::new();
-        files.insert(representative_member, result.report);
-        cluster.minimization = Some(ClusterMinimizationReport { mode, files });
 
+        match mode {
+            MinimizationMode::Representative => {
+                let mut result =
+                    minimize_source(&cluster.representative_source, cluster_key, api, config);
+                write_minimization_output(
+                    &cluster.representative_source,
+                    &unique_destination,
+                    &mut result,
+                )?;
+                if let Some(idx) = result.crashing_request_index {
+                    cluster.representative_crashing_request_index = idx;
+                }
+                result.report.output = Some(relative_string(output_directory, &unique_destination));
+                files.insert(representative_member, result.report);
+            }
+            MinimizationMode::All => {
+                let mut representative_minimized = None;
+
+                for member in &cluster.members {
+                    let source = crash_directory.join(member);
+                    let dest = minimized_directory.join(member);
+                    let mut result = minimize_source(&source, cluster_key, api, config);
+                    write_minimization_output(&source, &dest, &mut result)?;
+                    if member == &representative_member {
+                        representative_minimized = Some(dest.clone());
+                        if let Some(idx) = result.crashing_request_index {
+                            cluster.representative_crashing_request_index = idx;
+                        }
+                    }
+                    result.report.output = Some(relative_string(output_directory, &dest));
+                    files.insert(member.clone(), result.report);
+                }
+
+                let rep = representative_minimized.with_context(|| {
+                    format!(
+                        "Locating minimized representative for cluster {}",
+                        cluster.key
+                    )
+                })?;
+                fs::copy(&rep, &unique_destination).with_context(|| {
+                    format!(
+                        "Copying minimized representative to {}",
+                        unique_destination.display()
+                    )
+                })?;
+            }
+        }
+
+        cluster.representative = relative_string(output_directory, &unique_destination);
+        cluster.minimization = Some(ClusterMinimizationReport { mode, files });
         log::info!(
             "Crash minimization progress: {}/{total} clusters processed",
             index + 1
@@ -353,6 +413,28 @@ fn write_report(output_directory: &Path, report: &DedupReport) -> Result<()> {
     Ok(())
 }
 
+fn minimization_summary(clusters: &[CrashCluster]) -> Option<MinimizationSummary> {
+    let mut reports = clusters
+        .iter()
+        .filter_map(|c| c.minimization.as_ref())
+        .flat_map(|m| m.files.values())
+        .peekable();
+    reports.peek()?;
+    let mut summary = MinimizationSummary {
+        minimized: 0,
+        unchanged: 0,
+        failed: 0,
+    };
+    for report in reports {
+        match report.status {
+            MinimizationStatus::Minimized => summary.minimized += 1,
+            MinimizationStatus::Unchanged => summary.unchanged += 1,
+            MinimizationStatus::Failed => summary.failed += 1,
+        }
+    }
+    Some(summary)
+}
+
 fn log_summary(summary: &DedupSummary, output_directory: &Path) {
     log::info!(
         "Dedup complete: {} crash files, {} reproduced, {} unique clusters, {} non-reproducible, {} skipped. Output: {}",
@@ -363,6 +445,14 @@ fn log_summary(summary: &DedupSummary, output_directory: &Path) {
         summary.skipped,
         output_directory.display()
     );
+    if let Some(m) = &summary.minimization {
+        log::info!(
+            "Minimization: {} minimized, {} unchanged, {} failed",
+            m.minimized,
+            m.unchanged,
+            m.failed
+        );
+    }
 }
 
 enum FileOutcome {
@@ -545,6 +635,42 @@ mod tests {
             err.to_string()
                 .contains("must not be inside or equal to crash directory")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn copy_unique_representatives_names_and_updates_paths() -> Result<()> {
+        let dir = TempDir::new()?;
+        let crash_a = dir.path().join("a-crash");
+        let crash_b = dir.path().join("b-crash");
+        fs::write(&crash_a, b"aaa")?;
+        fs::write(&crash_b, b"bbb")?;
+
+        let output = dir.path().join("out");
+        let mut clusters = BTreeMap::new();
+        add_to_clusters(
+            &mut clusters,
+            &crash_a,
+            String::from("a-crash"),
+            3,
+            make_crash("GET /a"),
+        );
+        add_to_clusters(
+            &mut clusters,
+            &crash_b,
+            String::from("b-crash"),
+            3,
+            make_crash("POST /b"),
+        );
+        copy_unique_representatives(&output, &mut clusters)?;
+
+        let reps: Vec<_> = clusters
+            .values()
+            .map(|c| c.representative.as_str())
+            .collect();
+        assert_eq!(reps, ["unique/000000_a-crash", "unique/000001_b-crash"]);
+        assert_eq!(fs::read(output.join("unique/000000_a-crash"))?, b"aaa");
+        assert_eq!(fs::read(output.join("unique/000001_b-crash"))?, b"bbb");
         Ok(())
     }
 }

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -1,0 +1,2 @@
+mod identity;
+pub mod replay;

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -1,4 +1,5 @@
 mod identity;
+pub mod minimizer;
 pub mod replay;
 
 use std::{

--- a/src/crash_dedup/mod.rs
+++ b/src/crash_dedup/mod.rs
@@ -9,6 +9,11 @@
 //! 5. Optionally minimize representatives (or all members) while preserving cluster key.
 //! 6. Emit `clusters.json` with summary counts and per-cluster details.
 //!
+//! Replay classifies crashes using the configured crash criteria (`--crash-criteria`
+//! or the config file's `crash_criteria`). This should match the value used during the
+//! fuzzing run that produced the crash files; otherwise crash files may be reported as
+//! non-reproducible.
+//!
 //! Where to find things:
 //! - [`dedup_crashes`] orchestrates end-to-end command behavior.
 //! - `identity` defines crash identity dimensions and cluster keys.

--- a/src/crash_dedup/replay.rs
+++ b/src/crash_dedup/replay.rs
@@ -164,6 +164,14 @@ pub fn replay_input(
     )
 }
 
+struct ReplayContext<'a> {
+    api: &'a Spec,
+    request_timeout_ms: u64,
+    crash_criteria: &'a [ValidationErrorDiscriminants],
+    client: &'a reqwest::blocking::Client,
+    cookie_store: &'a std::sync::Arc<reqwest_cookie_store::CookieStoreMutex>,
+}
+
 fn replay_input_with_client(
     input: &OpenApiInput,
     api: &Spec,
@@ -173,17 +181,20 @@ fn replay_input_with_client(
     authentication: &mut Authentication,
     cookie_store: &std::sync::Arc<reqwest_cookie_store::CookieStoreMutex>,
 ) -> Result<ReplayOutcome> {
+    let ctx = ReplayContext {
+        api,
+        request_timeout_ms,
+        crash_criteria,
+        client,
+        cookie_store,
+    };
     let mut parameter_feedback = ParameterFeedback::new(input.len());
     for (request_index, request) in input.0.iter().enumerate() {
         match replay_request(
             request_index,
             request,
-            api,
-            request_timeout_ms,
-            crash_criteria,
-            client,
+            &ctx,
             authentication,
-            cookie_store,
             &mut parameter_feedback,
         )? {
             ReplayStep::Continue => {}
@@ -198,12 +209,8 @@ fn replay_input_with_client(
 fn replay_request(
     request_index: usize,
     request: &OpenApiRequest,
-    api: &Spec,
-    request_timeout_ms: u64,
-    crash_criteria: &[ValidationErrorDiscriminants],
-    client: &reqwest::blocking::Client,
+    ctx: &ReplayContext<'_>,
     authentication: &mut Authentication,
-    cookie_store: &std::sync::Arc<reqwest_cookie_store::CookieStoreMutex>,
     parameter_feedback: &mut ParameterFeedback,
 ) -> Result<ReplayStep> {
     let mut request = request.clone();
@@ -218,11 +225,11 @@ fn replay_request(
     parameter_feedback.process_request(request_index, &request);
 
     let request_built = match build_replay_request(
-        client,
+        ctx.client,
         authentication,
-        cookie_store,
-        api,
-        request_timeout_ms,
+        ctx.cookie_store,
+        ctx.api,
+        ctx.request_timeout_ms,
         &request,
     )? {
         BuiltReplayRequest::Request(request) => *request,
@@ -230,7 +237,7 @@ fn replay_request(
         BuiltReplayRequest::Stop(reason) => return Ok(ReplayStep::Stop(reason)),
     };
 
-    match client.execute(request_built) {
+    match ctx.client.execute(request_built) {
         Ok(response) => {
             let response: Response = response.into();
             let response_class = coarse_response_class(&response);
@@ -240,8 +247,8 @@ fn replay_request(
                 request_index,
                 &request,
                 &response,
-                api,
-                crash_criteria,
+                ctx.api,
+                ctx.crash_criteria,
                 &mut exit_kind,
                 parameter_feedback,
             );

--- a/src/crash_dedup/replay.rs
+++ b/src/crash_dedup/replay.rs
@@ -1,3 +1,9 @@
+//! Crash replay engine used by dedup and minimization.
+//!
+//! Given an `OpenApiInput`, this module rebuilds and executes requests in order,
+//! tracks parameter feedback/backreferences, and reports whether replay crashed,
+//! completed, or stopped early.
+
 use std::time::Duration;
 
 use anyhow::Result;
@@ -33,6 +39,10 @@ pub enum ReplayOutcome {
     Stopped(String),
 }
 
+/// Classify response payload into broad buckets used for crash identity keys.
+///
+/// Nice to know: this operates on buffered response wrapper, so body reads here
+/// do not consume data needed later by validation.
 fn coarse_response_class(response: &Response) -> ResponseClass {
     // Uses WuppieFuzz's buffered Response wrapper, so reading the body here
     // does not consume it for later validation or status access.
@@ -59,6 +69,7 @@ fn coarse_response_class(response: &Response) -> ResponseClass {
     }
 }
 
+/// Classify textual body as HTML using lightweight heuristics.
 fn looks_like_html(text: &str) -> bool {
     let trimmed = text.trim_start().to_ascii_lowercase();
     trimmed.starts_with("<!doctype html>")
@@ -66,6 +77,9 @@ fn looks_like_html(text: &str) -> bool {
         || trimmed.contains("<body")
 }
 
+/// Compute crash kind for a crashing HTTP response.
+///
+/// 5xx status takes precedence over validation-based crash classification.
 fn response_crash_kind(
     status: StatusCode,
     validation_error: Option<&ValidationError>,
@@ -78,6 +92,7 @@ fn response_crash_kind(
         .unwrap_or(CrashKind::HttpResponseCrash)
 }
 
+/// Map reqwest transport error to coarse crash and response classes.
 fn transport_identity_parts(error: &reqwest::Error) -> (CrashKind, ResponseClass) {
     if error.is_timeout() {
         (CrashKind::TransportTimeout, ResponseClass::TransportTimeout)
@@ -99,6 +114,7 @@ fn transport_identity_parts(error: &reqwest::Error) -> (CrashKind, ResponseClass
     }
 }
 
+/// Build crash identity for response-based crashes.
 fn observed_response_identity(
     status: StatusCode,
     validation_error: Option<&ValidationError>,
@@ -115,6 +131,7 @@ fn observed_response_identity(
     }
 }
 
+/// Build crash identity for transport-layer failures.
 fn observed_transport_identity(error: &reqwest::Error, endpoint: Option<String>) -> CrashIdentity {
     let (crash_kind, response_class) = transport_identity_parts(error);
     CrashIdentity {
@@ -129,6 +146,7 @@ fn observed_transport_identity(error: &reqwest::Error, endpoint: Option<String>)
     }
 }
 
+/// Render endpoint as `METHOD /path` for report/debug identity fields.
 fn endpoint_string(request: &OpenApiRequest) -> String {
     format!("{} {}", request.method, request.path)
 }
@@ -146,6 +164,10 @@ enum BuiltReplayRequest {
     Stop(String),
 }
 
+/// Replay input with default authenticated client built from spec/config.
+///
+/// Returns first observed crash, `Completed` if all requests execute without
+/// crash criteria, or `Stopped` when replay cannot continue safely.
 pub fn replay_input(
     input: &OpenApiInput,
     api: &Spec,
@@ -172,6 +194,10 @@ struct ReplayContext<'a> {
     cookie_store: &'a std::sync::Arc<reqwest_cookie_store::CookieStoreMutex>,
 }
 
+/// Replay complete input sequence with caller-provided HTTP client state.
+///
+/// This variant is used by tests and internal callers that want explicit client,
+/// auth, timeout, and cookie-store control.
 fn replay_input_with_client(
     input: &OpenApiInput,
     api: &Spec,
@@ -206,6 +232,11 @@ fn replay_input_with_client(
     Ok(ReplayOutcome::Completed)
 }
 
+/// Replay one request and return whether replay should continue, stop, or crash.
+///
+/// Preconditions:
+/// - `parameter_feedback` must reflect all successfully replayed previous requests.
+/// - `request_index` must match request position in original input ordering.
 fn replay_request(
     request_index: usize,
     request: &OpenApiRequest,
@@ -274,6 +305,12 @@ fn replay_request(
     }
 }
 
+/// Build concrete reqwest request for replay.
+///
+/// Returns:
+/// - `Request` when build succeeds.
+/// - `Skip` when request cannot be instantiated from API/input.
+/// - `Stop` when reqwest rejects built request.
 fn build_replay_request(
     client: &reqwest::blocking::Client,
     authentication: &mut Authentication,

--- a/src/crash_dedup/replay.rs
+++ b/src/crash_dedup/replay.rs
@@ -1,0 +1,404 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use libafl::executors::ExitKind;
+use libafl_bolts::HasLen;
+use reqwest::StatusCode;
+use strum::IntoDiscriminant;
+
+use crate::{
+    authentication::{Authentication, build_http_client},
+    configuration::Configuration,
+    crash_dedup::identity::{CrashIdentity, CrashKind, ObservedExitKind, ResponseClass},
+    executor::process_response,
+    input::{OpenApiInput, OpenApiRequest},
+    openapi::{
+        build_request::build_request_from_input,
+        spec::Spec,
+        validate_response::{Response, ValidationError, ValidationErrorDiscriminants},
+    },
+    parameter_feedback::ParameterFeedback,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObservedCrash {
+    pub identity: CrashIdentity,
+    pub crashing_request_index: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReplayOutcome {
+    Crash(ObservedCrash),
+    Completed,
+    Stopped(String),
+}
+
+fn coarse_response_class(response: &Response) -> ResponseClass {
+    // Uses WuppieFuzz's buffered Response wrapper, so reading the body here
+    // does not consume it for later validation or status access.
+    if response.content_length() == 0 {
+        return ResponseClass::Empty;
+    }
+
+    if response.json::<serde_json::Value>().is_ok() {
+        return ResponseClass::Json;
+    }
+
+    match response.text() {
+        Ok(text) => {
+            let trimmed = text.trim_start();
+            if trimmed.starts_with('{') || trimmed.starts_with('[') {
+                ResponseClass::InvalidJson
+            } else if looks_like_html(&text) {
+                ResponseClass::Html
+            } else {
+                ResponseClass::Plaintext
+            }
+        }
+        Err(_) => ResponseClass::BinaryOrUnknown,
+    }
+}
+
+fn looks_like_html(text: &str) -> bool {
+    let trimmed = text.trim_start().to_ascii_lowercase();
+    trimmed.starts_with("<!doctype html>")
+        || trimmed.starts_with("<html")
+        || trimmed.contains("<body")
+}
+
+fn response_crash_kind(
+    status: StatusCode,
+    validation_error: Option<&ValidationError>,
+) -> CrashKind {
+    if status.is_server_error() {
+        return CrashKind::Http5xx;
+    }
+    validation_error
+        .map(|err| CrashKind::Validation(err.discriminant()))
+        .unwrap_or(CrashKind::HttpResponseCrash)
+}
+
+fn transport_identity_parts(error: &reqwest::Error) -> (CrashKind, ResponseClass) {
+    if error.is_timeout() {
+        (CrashKind::TransportTimeout, ResponseClass::TransportTimeout)
+    } else if error.is_connect() {
+        (CrashKind::TransportConnectionError, ResponseClass::TransportConnectionError)
+    } else if error.is_decode() {
+        (CrashKind::TransportDecodeError, ResponseClass::TransportDecodeError)
+    } else {
+        (CrashKind::TransportUnknownError, ResponseClass::TransportUnknownError)
+    }
+}
+
+fn observed_response_identity(
+    status: StatusCode,
+    validation_error: Option<&ValidationError>,
+    endpoint: Option<String>,
+    response_class: ResponseClass,
+) -> CrashIdentity {
+    CrashIdentity {
+        exit_kind: ObservedExitKind::Crash,
+        crash_kind: response_crash_kind(status, validation_error),
+        http_status: Some(status.as_u16()),
+        validation_error_discriminant: validation_error.map(|err| err.discriminant()),
+        endpoint,
+        response_class,
+    }
+}
+
+fn observed_transport_identity(error: &reqwest::Error, endpoint: Option<String>) -> CrashIdentity {
+    let (crash_kind, response_class) = transport_identity_parts(error);
+    CrashIdentity {
+        // The executor reports all transport failures as LibAFL timeouts; CrashKind keeps
+        // the more specific timeout/connection/decode distinction.
+        exit_kind: ObservedExitKind::Timeout,
+        crash_kind,
+        http_status: None,
+        validation_error_discriminant: None,
+        endpoint,
+        response_class,
+    }
+}
+
+fn endpoint_string(request: &OpenApiRequest) -> String {
+    format!("{} {}", request.method, request.path)
+}
+
+enum ReplayStep {
+    Continue,
+    Stop(String),
+    Crash(ObservedCrash),
+}
+
+enum BuiltReplayRequest {
+    Request(reqwest::blocking::Request),
+    Skip,
+    Stop(String),
+}
+
+pub fn replay_input(
+    input: &OpenApiInput,
+    api: &Spec,
+    config: &Configuration,
+) -> Result<ReplayOutcome> {
+    let (mut authentication, cookie_store, client) = build_http_client(api)?;
+
+    replay_input_with_client(
+        input,
+        api,
+        config.request_timeout,
+        &config.crash_criteria,
+        &client,
+        &mut authentication,
+        &cookie_store,
+    )
+}
+
+fn replay_input_with_client(
+    input: &OpenApiInput,
+    api: &Spec,
+    request_timeout_ms: u64,
+    crash_criteria: &[ValidationErrorDiscriminants],
+    client: &reqwest::blocking::Client,
+    authentication: &mut Authentication,
+    cookie_store: &std::sync::Arc<reqwest_cookie_store::CookieStoreMutex>,
+) -> Result<ReplayOutcome> {
+    let mut parameter_feedback = ParameterFeedback::new(input.len());
+    for (request_index, request) in input.0.iter().enumerate() {
+        match replay_request(
+            request_index,
+            request,
+            api,
+            request_timeout_ms,
+            crash_criteria,
+            client,
+            authentication,
+            cookie_store,
+            &mut parameter_feedback,
+        )? {
+            ReplayStep::Continue => {}
+            ReplayStep::Stop(reason) => return Ok(ReplayOutcome::Stopped(reason)),
+            ReplayStep::Crash(crash) => return Ok(ReplayOutcome::Crash(crash)),
+        }
+    }
+
+    Ok(ReplayOutcome::Completed)
+}
+
+fn replay_request(
+    request_index: usize,
+    request: &OpenApiRequest,
+    api: &Spec,
+    request_timeout_ms: u64,
+    crash_criteria: &[ValidationErrorDiscriminants],
+    client: &reqwest::blocking::Client,
+    authentication: &mut Authentication,
+    cookie_store: &std::sync::Arc<reqwest_cookie_store::CookieStoreMutex>,
+    parameter_feedback: &mut ParameterFeedback,
+) -> Result<ReplayStep> {
+    let mut request = request.clone();
+
+    if let Err(error) = request.resolve_parameter_references(parameter_feedback) {
+        log::debug!(
+            "Cannot instantiate request while replaying crash: missing backreference: {error}"
+        );
+        return Ok(ReplayStep::Stop(error.to_string()));
+    }
+
+    parameter_feedback.process_request(request_index, &request);
+
+    let request_built = match build_replay_request(
+        client,
+        authentication,
+        cookie_store,
+        api,
+        request_timeout_ms,
+        &request,
+    )? {
+        BuiltReplayRequest::Request(request) => request,
+        BuiltReplayRequest::Skip => return Ok(ReplayStep::Continue),
+        BuiltReplayRequest::Stop(reason) => return Ok(ReplayStep::Stop(reason)),
+    };
+
+    match client.execute(request_built) {
+        Ok(response) => {
+            let response: Response = response.into();
+            let response_class = coarse_response_class(&response);
+            let mut exit_kind = ExitKind::Ok;
+
+            let validation_error = process_response(
+                request_index,
+                &request,
+                &response,
+                api,
+                crash_criteria,
+                &mut exit_kind,
+                parameter_feedback,
+            );
+
+            if exit_kind == ExitKind::Crash {
+                Ok(ReplayStep::Crash(ObservedCrash {
+                    identity: observed_response_identity(
+                        response.status(),
+                        validation_error.as_ref(),
+                        Some(endpoint_string(&request)),
+                        response_class,
+                    ),
+                    crashing_request_index: request_index,
+                }))
+            } else {
+                Ok(ReplayStep::Continue)
+            }
+        }
+        Err(error) => Ok(ReplayStep::Crash(ObservedCrash {
+            identity: observed_transport_identity(&error, Some(endpoint_string(&request))),
+            crashing_request_index: request_index,
+        })),
+    }
+}
+
+fn build_replay_request(
+    client: &reqwest::blocking::Client,
+    authentication: &mut Authentication,
+    cookie_store: &std::sync::Arc<reqwest_cookie_store::CookieStoreMutex>,
+    api: &Spec,
+    request_timeout_ms: u64,
+    request: &OpenApiRequest,
+) -> Result<BuiltReplayRequest> {
+    let request_builder =
+        match build_request_from_input(client, authentication, cookie_store, api, request) {
+            Ok(builder) => builder.timeout(Duration::from_millis(request_timeout_ms)),
+            Err(error) => {
+                log::warn!("Could not generate HTTP request while replaying crash: {error}");
+                return Ok(BuiltReplayRequest::Skip);
+            }
+        };
+
+    match request_builder.build() {
+        Ok(request) => Ok(BuiltReplayRequest::Request(request)),
+        Err(error) => {
+            log::warn!("Reqwest failed to build replay request: {error}");
+            Ok(BuiltReplayRequest::Stop(error.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::json;
+    use strum::VariantArray;
+
+    use super::*;
+    use crate::{
+        input::{
+            Body, Method, ParameterContents,
+            parameter::{OReference, ParameterKind},
+        },
+        parameter_access::{ParameterAccess, ParameterAccessElements},
+    };
+
+    fn test_spec(server_url: String) -> Spec {
+        let raw_spec: oas3::Spec = serde_json::from_value(json!({
+            "openapi": "3.1.0",
+            "info": { "title": "test", "version": "1.0.0" },
+            "servers": [{ "url": server_url }],
+            "paths": {
+                "/items": {
+                    "get": { "responses": { "200": { "description": "ok" } } }
+                }
+            }
+        }))
+        .expect("test OpenAPI spec should deserialize");
+        Spec::from(raw_spec)
+    }
+
+    fn test_client_parts() -> (
+        Authentication,
+        Arc<reqwest_cookie_store::CookieStoreMutex>,
+        reqwest::blocking::Client,
+    ) {
+        let cookie_store = Arc::new(reqwest_cookie_store::CookieStoreMutex::new(
+            reqwest_cookie_store::CookieStore::default(),
+        ));
+        let client = reqwest::blocking::Client::builder()
+            .cookie_provider(Arc::clone(&cookie_store))
+            .build()
+            .expect("test HTTP client should build");
+        (Authentication::None, cookie_store, client)
+    }
+
+    #[test]
+    fn replay_input_returns_observed_crash_for_http_500() -> anyhow::Result<()> {
+        let mut server = mockito::Server::new();
+        let _mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(500)
+            .with_body(r#"{"error":"boom"}"#)
+            .create();
+
+        let api = test_spec(server.url());
+        let (mut authentication, cookie_store, client) = test_client_parts();
+        let input = OpenApiInput(vec![OpenApiRequest {
+            method: Method::Get,
+            path: "/items".into(),
+            body: Body::Empty,
+            parameters: Default::default(),
+        }]);
+
+        let outcome = replay_input_with_client(
+            &input,
+            &api,
+            30_000,
+            ValidationErrorDiscriminants::VARIANTS,
+            &client,
+            &mut authentication,
+            &cookie_store,
+        )?;
+        let ReplayOutcome::Crash(crash) = outcome else {
+            panic!("HTTP 500 should be observed as a crash, got {outcome:?}");
+        };
+
+        assert_eq!(crash.identity.crash_kind, CrashKind::Http5xx);
+        assert_eq!(crash.identity.http_status, Some(500));
+        assert_eq!(crash.identity.endpoint.as_deref(), Some("GET /items"));
+        assert_eq!(crash.identity.response_class, ResponseClass::Json);
+
+        Ok(())
+    }
+
+    #[test]
+    fn unresolved_backreference_stops_replay() -> anyhow::Result<()> {
+        let api = test_spec(String::from("http://127.0.0.1:9"));
+        let (mut authentication, cookie_store, client) = test_client_parts();
+        let input = OpenApiInput(vec![OpenApiRequest {
+            method: Method::Get,
+            path: "/items".into(),
+            body: Body::Empty,
+            parameters: [(
+                (String::from("id"), ParameterKind::Query),
+                ParameterContents::OReference(OReference {
+                    request_index: 0,
+                    parameter_access: ParameterAccess::response_body(
+                        ParameterAccessElements::new(),
+                    ),
+                }),
+            )]
+            .into(),
+        }]);
+
+        let outcome = replay_input_with_client(
+            &input,
+            &api,
+            30_000,
+            ValidationErrorDiscriminants::VARIANTS,
+            &client,
+            &mut authentication,
+            &cookie_store,
+        )?;
+
+        assert!(matches!(outcome, ReplayOutcome::Stopped(_)));
+        Ok(())
+    }
+}

--- a/src/crash_dedup/replay.rs
+++ b/src/crash_dedup/replay.rs
@@ -82,11 +82,20 @@ fn transport_identity_parts(error: &reqwest::Error) -> (CrashKind, ResponseClass
     if error.is_timeout() {
         (CrashKind::TransportTimeout, ResponseClass::TransportTimeout)
     } else if error.is_connect() {
-        (CrashKind::TransportConnectionError, ResponseClass::TransportConnectionError)
+        (
+            CrashKind::TransportConnectionError,
+            ResponseClass::TransportConnectionError,
+        )
     } else if error.is_decode() {
-        (CrashKind::TransportDecodeError, ResponseClass::TransportDecodeError)
+        (
+            CrashKind::TransportDecodeError,
+            ResponseClass::TransportDecodeError,
+        )
     } else {
-        (CrashKind::TransportUnknownError, ResponseClass::TransportUnknownError)
+        (
+            CrashKind::TransportUnknownError,
+            ResponseClass::TransportUnknownError,
+        )
     }
 }
 
@@ -131,7 +140,8 @@ enum ReplayStep {
 }
 
 enum BuiltReplayRequest {
-    Request(reqwest::blocking::Request),
+    // Boxed to avoid a large size difference between variants (reqwest::blocking::Request is ~304 bytes).
+    Request(Box<reqwest::blocking::Request>),
     Skip,
     Stop(String),
 }
@@ -215,7 +225,7 @@ fn replay_request(
         request_timeout_ms,
         &request,
     )? {
-        BuiltReplayRequest::Request(request) => request,
+        BuiltReplayRequest::Request(request) => *request,
         BuiltReplayRequest::Skip => return Ok(ReplayStep::Continue),
         BuiltReplayRequest::Stop(reason) => return Ok(ReplayStep::Stop(reason)),
     };
@@ -275,7 +285,7 @@ fn build_replay_request(
         };
 
     match request_builder.build() {
-        Ok(request) => Ok(BuiltReplayRequest::Request(request)),
+        Ok(request) => Ok(BuiltReplayRequest::Request(Box::new(request))),
         Err(error) => {
             log::warn!("Reqwest failed to build replay request: {error}");
             Ok(BuiltReplayRequest::Stop(error.to_string()))
@@ -376,16 +386,17 @@ mod tests {
             method: Method::Get,
             path: "/items".into(),
             body: Body::Empty,
-            parameters: [(
-                (String::from("id"), ParameterKind::Query),
-                ParameterContents::OReference(OReference {
-                    request_index: 0,
-                    parameter_access: ParameterAccess::response_body(
-                        ParameterAccessElements::new(),
-                    ),
-                }),
-            )]
-            .into(),
+            parameters:
+                [(
+                    (String::from("id"), ParameterKind::Query),
+                    ParameterContents::OReference(OReference {
+                        request_index: 0,
+                        parameter_access: ParameterAccess::response_body(
+                            ParameterAccessElements::new(),
+                        ),
+                    }),
+                )]
+                .into(),
         }]);
 
         let outcome = replay_input_with_client(

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -150,6 +150,20 @@ impl Body {
     pub fn is_empty(&self) -> bool {
         matches!(self, Body::Empty)
     }
+
+    pub fn contents(&self) -> Option<&ParameterContents> {
+        match self {
+            Body::Empty => None,
+            Body::TextPlain(c) | Body::ApplicationJson(c) | Body::XWwwFormUrlencoded(c) => Some(c),
+        }
+    }
+
+    pub fn contents_mut(&mut self) -> Option<&mut ParameterContents> {
+        match self {
+            Body::Empty => None,
+            Body::TextPlain(c) | Body::ApplicationJson(c) | Body::XWwwFormUrlencoded(c) => Some(c),
+        }
+    }
 }
 
 impl OpenApiRequest {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,8 @@ use oas3::spec::Server;
 
 mod authentication;
 mod configuration;
-mod crash_dedup;
 pub mod coverage_clients;
+mod crash_dedup;
 pub mod executor;
 mod fuzzer;
 pub mod header;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ use oas3::spec::Server;
 
 mod authentication;
 mod configuration;
+mod crash_dedup;
 pub mod coverage_clients;
 pub mod executor;
 mod fuzzer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,9 @@ pub fn main() -> Result<()> {
         Commands::Dedup {
             crash_directory,
             output,
+            minimize,
             ..
-        } => crash_dedup::dedup_crashes(crash_directory, output),
+        } => crash_dedup::dedup_crashes(crash_directory, output, *minimize),
         Commands::Fuzz { .. } => fuzzer::fuzz(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,11 @@ pub fn main() -> Result<()> {
             ))
         }
         Commands::Reproduce { crash_file, .. } => reproducer::reproduce(crash_file),
+        Commands::Dedup {
+            crash_directory,
+            output,
+            ..
+        } => crash_dedup::dedup_crashes(crash_directory, output),
         Commands::Fuzz { .. } => fuzzer::fuzz(),
     }
 }


### PR DESCRIPTION
  Adds a dedup subcommand that takes a directory of crash files from a previous fuzzing run and groups them into unique crash clusters, then optionally minimizes each representative to its shortest reproducing sequence.


Usage:

Deduplicate only, it copies one representative per cluster to {ouput}/unique/ (so the user has access to all the crashes, but gets clustered output in form of the representatives)
`wuppiefuzz dedup crashes --output dedup-out --config config.yaml
`

Minimize the representative of each cluster (default when --minimize is used alone)
`wuppiefuzz dedup crashes --output dedup-out --config config.yaml --minimize
`

Minimizes every crash file in every cluster
` wuppiefuzz dedup crashes --output dedup-out --config config.yaml --minimize all
`

How clustering (deduplication) works

Each reproduced crash is assigned a CrashClusterKey derived from its exit kind, crash kind, HTTP status, validation error discriminant, endpoint, and response body class. Crashes that share the same key are grouped; the smallest file in each group becomes the representative.

How minimization works

Delta-debugging: iteratively attempts to remove one request at a time from the input sequence, replaying after each removal. A candidate is accepted only if it reproduces a crash with the same cluster key. Requests that are referenced by later requests (via backreferences) are never removed. Continues until no single request can be removed without losing the crash.

The output, besides the unique crashes is clusters.json which contains:

Top-level summary counts (total files, reproduced, unique clusters,
non-reproducible, skipped) plus, when minimization ran, a breakdown of how many inputs were minimized, unchanged, or failed.

Under clusters, each entry has:
  - key: the pipe-separated cluster key string (e.g. crash|http_5xx|500||POST/user|json)
  - representative: relative path of the output file for this cluster
  - members: all crash files that mapped to this cluster
  - member_count: number of members
  - representative_crashing_request_index: which request in the sequence triggered the crash
  - identity: human-readable breakdown of the crash identity fields
  - minimization: (when --minimize was used) mode, and per-file report with original/minimized request counts, removed count, status (minimized/unchanged/failed), and output path


My ideas for future work is:

To extend the dedup command to write cluster data to SQLite enabling the same Grafana dashboard workflow used for fuzzing campaigns, enabling tracking of unique cluster counts, member breakdowns by endpoint, and minimization effectiveness across runs.

Corpus re-seeding, we could feed minimized representatives back as seeds for a follow-up fuzzing run, letting the fuzzer explore from already-crashing inputs.

Sub-request minimization: the current minimizer removes whole requests, a second pass could shrink parameter values within the crashing request (trim strings, nudge numbers toward boundary values).

Stateful replay with Docker,  some crashes are non-reproducible because they depend on server state accumulated during the original fuzzing run. For the non-reproducible set, reset the target to a clean state (e.g. restart the Docker container) and retry. (But this would be a big change, could be extended for the whole fuzzing campaign to run with docker containers, having control over the API inside WuppieFuzz could be useful). 

Continuing on the topic of states, in my testing, usually non-reproducible crashse happen after a reset, my simple explanation for this is that the API state is not "dirty" enough after a reset, thus not reproducing the crash, therefore a more simpler way to handle non-reproducers is to just retry them at the end of the dedup run. (I think this would improve the reproductibility rate significantly without a significant amount of code change)



