### PR TITLE
Add OpenTelemetry-guided REST API fuzzing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features
 
 - Adds support for .NET coverage based on cobertura and dotnet-coverage in [#336](https://github.com/TNO-S3/WuppieFuzz/pull/336)
+- Adds support for coverage guidance using OpenTelemetry in [#358](https://github.com/TNO-S3/WuppieFuzz/pull/358)
 
 ## Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -138,6 +138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +181,58 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -435,7 +498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -575,6 +638,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +760,15 @@ name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1041,6 +1125,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1120,10 +1205,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1145,6 +1252,7 @@ checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1385,6 +1493,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1977,6 +2098,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,6 +2453,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "base64 0.22.1",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2556,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2470,6 +2663,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2629,6 +2869,15 @@ checksum = "79e745eeef604742ec751000e44d91cdc0552aacacb2c74bee88cc7685918cfa"
 dependencies = [
  "rand 0.10.2",
  "regex-syntax",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3060,6 +3309,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,7 +3392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -3143,7 +3403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -3351,7 +3611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3445,7 +3705,19 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3455,6 +3727,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3553,6 +3836,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,11 +3884,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3603,8 +3931,21 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3680,6 +4021,12 @@ checksum = "885c31f06fce836457fe3ef09a59f83fe8db95d270b11cd78f40a4666c4d1661"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -4220,6 +4567,7 @@ version = "1.6.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "axum",
  "base64 0.23.0",
  "build_html",
  "byteorder",
@@ -4229,6 +4577,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "env_logger 0.11.11",
+ "flate2",
  "indexmap",
  "indicatif",
  "iter-read",
@@ -4247,8 +4596,11 @@ dependencies = [
  "once_cell",
  "openapiv3-extended",
  "openssl",
+ "opentelemetry-proto",
  "petgraph",
  "porter-stemmer",
+ "prost",
+ "prost-types",
  "rand 0.10.2",
  "rand_regex",
  "regex",
@@ -4262,6 +4614,9 @@ dependencies = [
  "serde_yaml",
  "strum",
  "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic",
  "unicode-truncate",
  "url",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,14 @@ walkdir = "2.5.0"
 z3 = "0.19.13"
 oas3 = { version = "0.22.0", features = ["yaml-spec"] }
 semver = "1.0.28"
+axum = "0.8"
+flate2 = "1.1.5"
+opentelemetry-proto = { version = "0.32.0", features = ["gen-tonic", "trace"] }
+prost = "0.14.1"
+prost-types = "0.14.1"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = { version = "0.14", features = ["transport", "gzip"] }
 
 [dev-dependencies]
 mockito = "1.7.2"

--- a/OPENTELEMETRY.md
+++ b/OPENTELEMETRY.md
@@ -1,0 +1,134 @@
+# OpenTelemetry coverage
+
+WuppieFuzz can use [OpenTelemetry](https://opentelemetry.io/) (OTel) traces as a coverage
+signal instead of a language-specific code coverage agent (Jacoco, LCOV, Coverband). This is
+useful when:
+
+- the target is composed of multiple services/languages and you want coverage across the
+  whole call chain, not just one process;
+- the target already has OTel auto-instrumentation (or can easily get it), but has no
+  Jacoco/LCOV/Coverband agent available;
+- you are fuzzing a black-box or closed-source component that only exposes tracing.
+
+Instead of reading a line/branch coverage bitmap from an agent, WuppieFuzz injects a W3C
+`traceparent` header into every request it sends, runs its own built-in OTLP receivers, and
+turns the spans the target reports back into a coverage bitmap keyed by span type and
+parent/child span edges. See the "How it works" section below for details.
+
+## 1. Instrument your target with OpenTelemetry
+
+Your application needs to export traces via OTLP (either OTLP/HTTP or OTLP/gRPC) and must
+propagate the incoming `traceparent` header to any spans it creates, including spans for
+calls to other services. This is the default behavior of OpenTelemetry SDKs and
+auto-instrumentation agents, so in most cases no additional code changes are required, only
+configuration.
+
+For example, for a Java target using the OpenTelemetry Java agent:
+
+```sh
+java -javaagent:opentelemetry-javaagent.jar \
+  -Dotel.traces.exporter=otlp \
+  -Dotel.metrics.exporter=none \
+  -Dotel.logs.exporter=none \
+  -Dotel.exporter.otlp.traces.endpoint=http://<wuppiefuzz-host>:4319/v1/traces \
+  -Dotel.exporter.otlp.traces.protocol=http/protobuf \
+  -jar your-service.jar
+```
+
+Point the exporter at whichever WuppieFuzz OTLP receiver you enable (HTTP defaults to port
+`4319`, gRPC to `4317`; see below). If the target runs in a container, make sure it can reach
+the host WuppieFuzz runs on — the receivers refuse to bind usefully to loopback-only
+addresses from inside a container, so use a routable IP, `host.docker.internal`, or a shared
+Docker network.
+
+Other languages/frameworks work the same way: any OpenTelemetry SDK or auto-instrumentation
+agent that exports traces over OTLP/HTTP or OTLP/gRPC and propagates the W3C trace context
+will work.
+
+## 2. Configure WuppieFuzz
+
+Set `coverage_format: otel` in your configuration file (or `--coverage-format otel` on the
+command line). No `coverage_host` is needed for OTel coverage: WuppieFuzz doesn't connect out
+to an agent, it listens for spans the target pushes to it.
+
+```yaml
+coverage_format: otel
+
+openapi_spec: openapi_spec.yaml
+target: http://localhost:8080
+
+# Optional: override where WuppieFuzz's built-in OTLP receivers listen.
+# Accepts "IP:PORT", "off" (disable that receiver), or omit for the default.
+otel_http_receiver_bind: 0.0.0.0:4319   # default when omitted
+otel_grpc_receiver_bind: 0.0.0.0:4317   # default when omitted
+```
+
+At least one of the two receivers must remain enabled. Notes on the bind options:
+
+- `otel_http_receiver_bind` defaults to `0.0.0.0:4319` and serves OTLP/HTTP at `/v1/traces`.
+- `otel_grpc_receiver_bind` defaults to the HTTP receiver's IP on port `4317`.
+- Set either one to `off` to disable that protocol (e.g. `otel_grpc_receiver_bind: off` if
+  your target only exports OTLP/HTTP).
+- `otel_receiver_bind` is a legacy alias for `otel_http_receiver_bind`, kept for backwards
+  compatibility.
+- The equivalent CLI flags are `--otel-http-receiver-bind`, `--otel-grpc-receiver-bind`, and
+  the legacy `--otel-receiver-bind`.
+
+Run the fuzzer as usual:
+
+```sh
+wuppiefuzz fuzz --config wuppiefuzz-otel.yaml
+```
+
+WuppieFuzz logs the addresses its receivers actually bound to on startup, e.g.:
+
+```
+Started built-in OTLP/HTTP receiver on 0.0.0.0:4319; point target auto-instrumentation at http://<this-host>:4319/v1/traces
+Started built-in OTLP/gRPC receiver on 0.0.0.0:4317; point target auto-instrumentation at grpc://<this-host>:4317
+```
+
+### Verifying instrumentation
+
+Coverage guidance from OTel is delayed and asynchronous: spans arrive after the HTTP response
+and are matched to the request sequence that produced them, so it can take a few seconds after
+startup before non-zero coverage shows up. If coverage stays at zero for longer than that,
+check that:
+
+- the target's OTLP exporter endpoint matches the address WuppieFuzz logged above;
+- the target is actually receiving and propagating the `traceparent` header WuppieFuzz sends
+  on each request (some frameworks require an OTel instrumentation package for the specific
+  HTTP server/client library in use);
+- nothing (a proxy, firewall, container network) is blocking traffic from the target to the
+  WuppieFuzz host on the receiver port.
+
+### Coverage reports
+
+With `report: true`, WuppieFuzz writes `otel_coverage.txt` to the report directory, listing
+every distinct span type and span-to-span edge observed during the run.
+
+## How it works
+
+- WuppieFuzz never parses source code or reads a coverage agent's bitmap for OTel coverage.
+  Instead, for each request it sends, it generates a random trace ID and injects a
+  `traceparent: 00-<trace-id>-<span-id>-01` header (per the
+  [W3C Trace Context spec](https://www.w3.org/TR/trace-context/)).
+- The target's own OpenTelemetry instrumentation continues that trace and exports the
+  resulting spans to WuppieFuzz's built-in OTLP/HTTP or OTLP/gRPC receiver.
+- Each span is reduced to a key of `(service, span kind, operation)`, where the operation
+  prefers a normalized HTTP route template or RPC method name over the raw span name so that
+  path parameters (e.g. `/users/123` vs `/users/456`) don't create spurious new coverage.
+  New span keys, and new parent → child span key edges, each set a bit in the coverage
+  bitmap — this gives coverage over which operations and call paths were exercised across the
+  whole distributed system, not just line/branch coverage inside a single process.
+- Because spans can arrive well after the HTTP response, novel coverage is detected
+  asynchronously and the corresponding input is promoted into the fuzzer's corpus after the
+  fact, rather than being scored synchronously like other coverage clients.
+
+## Comparison to other coverage clients
+
+OTel coverage is coarser-grained than Jacoco/LCOV/Coverband (it can't see individual lines or
+branches inside a handler), and its feedback is noisier and slower due to the asynchronous,
+best-effort nature of trace export. Its advantage is that it works across service and language
+boundaries without needing a language-specific coverage agent in every component, so it's best
+used for multi-service or black-box targets rather than as a strict replacement where
+fine-grained code coverage is already available.

--- a/SBOM.txt
+++ b/SBOM.txt
@@ -25,9 +25,6 @@ anstyle-query 1.1.5
 anstyle-wincon 3.0.11
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
-anyhow 1.0.104
-	licensed under "Apache-2.0 OR MIT"
-	by David Tolnay <dtolnay@gmail.com>
 atomic-waker 1.1.2
 	licensed under "Apache-2.0 OR MIT"
 	by Stjepan Glavina <stjepang@gmail.com>|Contributors to futures-rs
@@ -37,6 +34,12 @@ aws-lc-rs 1.17.3
 aws-lc-sys 0.43.0
 	licensed under "(Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0) AND (Apache-2.0 OR ISC) AND Apache-2.0 AND BSD-3-Clause AND ISC AND MIT"
 	by AWS-LC
+axum 0.8.9
+	licensed under "MIT"
+	by unspecified authors
+axum-core 0.5.6
+	licensed under "MIT"
+	by unspecified authors
 backtrace 0.3.76
 	licensed under "Apache-2.0 OR MIT"
 	by The Rust Project Developers
@@ -103,6 +106,9 @@ combine 4.6.7
 console 0.16.4
 	licensed under "MIT"
 	by unspecified authors
+const-hex 1.19.1
+	licensed under "Apache-2.0 OR MIT"
+	by DaniPopes <57450786+DaniPopes@users.noreply.github.com>
 const_format 0.2.36
 	licensed under "Zlib"
 	by rodrimati1992 <rodrimatt1985@gmail.com>
@@ -124,9 +130,15 @@ core-foundation 0.10.1
 core-foundation-sys 0.8.7
 	licensed under "Apache-2.0 OR MIT"
 	by The Servo Project Developers
+cpufeatures 0.2.17
+	licensed under "Apache-2.0 OR MIT"
+	by RustCrypto Developers
 cpufeatures 0.3.0
 	licensed under "Apache-2.0 OR MIT"
 	by RustCrypto Developers
+crc32fast 1.5.0
+	licensed under "Apache-2.0 OR MIT"
+	by Sam Rijs <srijs@airpost.net>|Alex Crichton <alex@alexcrichton.com>
 ctor 0.6.3
 	licensed under "Apache-2.0 OR MIT"
 	by Matt Mastracci <matthew@mastracci.com>
@@ -199,6 +211,9 @@ fastbloom 0.14.1
 fixedbitset 0.5.7
 	licensed under "Apache-2.0 OR MIT"
 	by bluss
+flate2 1.1.9
+	licensed under "Apache-2.0 OR MIT"
+	by Alex Crichton <alex@alexcrichton.com>|Josh Triplett <josh@joshtriplett.org>
 fnv 1.0.7
 	licensed under "Apache-2.0 OR MIT"
 	by Alex Crichton <alex@alexcrichton.com>
@@ -226,7 +241,13 @@ futures-channel 0.3.33
 futures-core 0.3.33
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
+futures-executor 0.3.33
+	licensed under "Apache-2.0 OR MIT"
+	by unspecified authors
 futures-io 0.3.33
+	licensed under "Apache-2.0 OR MIT"
+	by unspecified authors
+futures-macro 0.3.33
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
 futures-sink 0.3.33
@@ -289,6 +310,9 @@ hyper 1.11.0
 hyper-rustls 0.27.9
 	licensed under "Apache-2.0 OR ISC OR MIT"
 	by unspecified authors
+hyper-timeout 0.5.2
+	licensed under "Apache-2.0 OR MIT"
+	by Herman J. Radtke III <herman@hermanradtke.com>
 hyper-util 0.1.20
 	licensed under "MIT"
 	by Sean McArthur <sean@seanmonstar.com>
@@ -415,6 +439,9 @@ lru-slab 0.1.2
 mach2 0.5.0
 	licensed under "Apache-2.0 OR BSD-2-Clause OR MIT"
 	by unspecified authors
+matchit 0.8.4
+	licensed under "BSD-3-Clause AND MIT"
+	by Ibraheem Ahmed <ibraheem@ibraheem.ca>
 memchr 2.8.3
 	licensed under "MIT OR Unlicense"
 	by Andrew Gallant <jamslam@gmail.com>|bluss
@@ -493,6 +520,15 @@ openssl-probe 0.2.1
 openssl-sys 0.9.117
 	licensed under "MIT"
 	by Alex Crichton <alex@alexcrichton.com>|Steven Fackler <sfackler@gmail.com>
+opentelemetry 0.32.0
+	licensed under "Apache-2.0"
+	by unspecified authors
+opentelemetry-proto 0.32.0
+	licensed under "Apache-2.0"
+	by unspecified authors
+opentelemetry_sdk 0.32.1
+	licensed under "Apache-2.0"
+	by unspecified authors
 parking_lot 0.12.5
 	licensed under "Apache-2.0 OR MIT"
 	by Amanieu d'Antras <amanieu@gmail.com>
@@ -505,6 +541,12 @@ percent-encoding 2.3.2
 petgraph 0.8.3
 	licensed under "Apache-2.0 OR MIT"
 	by bluss|mitchmindtree
+pin-project 1.1.13
+	licensed under "Apache-2.0 OR MIT"
+	by unspecified authors
+pin-project-internal 1.1.13
+	licensed under "Apache-2.0 OR MIT"
+	by unspecified authors
 pin-project-lite 0.2.17
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
@@ -526,6 +568,21 @@ potential_utf 0.1.5
 powerfmt 0.2.0
 	licensed under "Apache-2.0 OR MIT"
 	by Jacob Pratt <jacob@jhpratt.dev>
+ppv-lite86 0.2.21
+	licensed under "Apache-2.0 OR MIT"
+	by The CryptoCorrosion Contributors
+proptest 1.11.0
+	licensed under "Apache-2.0 OR MIT"
+	by Jason Lingle
+prost 0.14.4
+	licensed under "Apache-2.0"
+	by Dan Burkert <dan@danburkert.com>|Lucio Franco <luciofranco14@gmail.com>|Casper Meijn <casper@meijn.net>|Tokio Contributors <team@tokio.rs>
+prost-derive 0.14.4
+	licensed under "Apache-2.0"
+	by Dan Burkert <dan@danburkert.com>|Lucio Franco <luciofranco14@gmail.com>|Casper Meijn <casper@meijn.net>|Tokio Contributors <team@tokio.rs>
+prost-types 0.14.4
+	licensed under "Apache-2.0"
+	by Dan Burkert <dan@danburkert.com>|Lucio Franco <luciofranco14@gmail.com>|Casper Meijn <casper@meijn.net>|Tokio Contributors <team@tokio.rs>
 psl-types 2.0.11
 	licensed under "Apache-2.0 OR MIT"
 	by rushmorem <rushmore@webenchanter.com>
@@ -547,9 +604,15 @@ r-efi 5.3.0
 r-efi 6.0.0
 	licensed under "Apache-2.0 OR LGPL-2.1-or-later OR MIT"
 	by unspecified authors
+rand 0.9.4
+	licensed under "Apache-2.0 OR MIT"
+	by The Rand Project Developers|The Rust Project Developers
 rand 0.10.2
 	licensed under "Apache-2.0 OR MIT"
 	by The Rand Project Developers|The Rust Project Developers
+rand_chacha 0.9.0
+	licensed under "Apache-2.0 OR MIT"
+	by The Rand Project Developers|The Rust Project Developers|The CryptoCorrosion Contributors
 rand_core 0.9.5
 	licensed under "Apache-2.0 OR MIT"
 	by The Rand Project Developers|The Rust Project Developers
@@ -562,6 +625,9 @@ rand_pcg 0.10.2
 rand_regex 0.19.0
 	licensed under "MIT"
 	by kennytm <kennytm@gmail.com>
+rand_xorshift 0.4.0
+	licensed under "Apache-2.0 OR MIT"
+	by The Rand Project Developers|The Rust Project Developers
 redox_syscall 0.5.18
 	licensed under "MIT"
 	by Jeremy Soller <jackpot51@gmail.com>
@@ -643,6 +709,9 @@ semver 1.0.28
 serde_core 1.0.229
 	licensed under "Apache-2.0 OR MIT"
 	by Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com>
+serde_path_to_error 0.1.20
+	licensed under "Apache-2.0 OR MIT"
+	by David Tolnay <dtolnay@gmail.com>
 serde_urlencoded 0.7.1
 	licensed under "Apache-2.0 OR MIT"
 	by Anthony Ramine <n.oxyde@gmail.com>
@@ -715,15 +784,24 @@ tinyvec 1.12.0
 tinyvec_macros 0.1.1
 	licensed under "Apache-2.0 OR MIT OR Zlib"
 	by Soveu <marx.tomasz@gmail.com>
-tokio 1.53.1
+tokio-macros 2.7.2
 	licensed under "MIT"
 	by Tokio Contributors <team@tokio.rs>
 tokio-rustls 0.26.4
 	licensed under "Apache-2.0 OR MIT"
 	by unspecified authors
+tokio-stream 0.1.19
+	licensed under "MIT"
+	by Tokio Contributors <team@tokio.rs>
 tokio-util 0.7.19
 	licensed under "MIT"
 	by Tokio Contributors <team@tokio.rs>
+tonic 0.14.6
+	licensed under "MIT"
+	by Lucio Franco <luciofranco14@gmail.com>
+tonic-prost 0.14.6
+	licensed under "MIT"
+	by Lucio Franco <luciofranco14@gmail.com>
 tower 0.5.3
 	licensed under "MIT"
 	by Tower Maintainers <team@tower-rs.com>
@@ -736,9 +814,6 @@ tower-layer 0.3.3
 tower-service 0.3.3
 	licensed under "MIT"
 	by Tower Maintainers <team@tower-rs.com>
-tracing 0.1.44
-	licensed under "MIT"
-	by Eliza Weisman <eliza@buoyant.io>|Tokio Contributors <team@tokio.rs>
 tracing-core 0.1.36
 	licensed under "MIT"
 	by Tokio Contributors <team@tokio.rs>
@@ -763,6 +838,9 @@ typewit 1.15.2
 uds 0.4.2
 	licensed under "Apache-2.0 OR MIT"
 	by Torbjørn Birch Moltu <t.b.moltu@lyse.net>
+unarray 0.1.4
+	licensed under "Apache-2.0 OR MIT"
+	by unspecified authors
 unicode-ident 1.0.24
 	licensed under "(Apache-2.0 OR MIT) AND Unicode-3.0"
 	by David Tolnay <dtolnay@gmail.com>
@@ -976,6 +1054,9 @@ zerovec 0.11.6
 zerovec-derive 0.11.3
 	licensed under "Unicode-3.0"
 	by Manish Goregaokar <manishsmail@gmail.com>
+zlib-rs 0.6.6
+	licensed under "Zlib"
+	by unspecified authors
 zmij 1.0.23
 	licensed under "MIT"
 	by David Tolnay <dtolnay@gmail.com>

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::TryFrom,
-    io,
+    fmt, io,
     io::ErrorKind,
     net::{SocketAddr, ToSocketAddrs},
     path::{Path, PathBuf},
@@ -8,7 +8,7 @@ use std::{
 
 use clap::{Parser, Subcommand, ValueEnum, value_parser};
 use libafl::schedulers::powersched::BaseSchedule;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de};
 use strum::VariantArray;
 use url::Url;
 
@@ -254,6 +254,20 @@ pub enum Commands {
         /// If no coverage is obtained anymore please check if the prefix is correct. If you use the trace debug level all skipped segment names are logged.
         #[arg(value_parser, long)]
         jacoco_class_prefix: Option<String>,
+
+        /// Legacy alias for --otel-http-receiver-bind. Accepts IP:PORT, `off`, or `null`.
+        #[arg(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+        otel_receiver_bind: ReceiverBindSetting,
+
+        /// Bind address for WuppieFuzz's built-in OTLP/HTTP receiver. Accepts IP:PORT, `off`, or `null`.
+        /// Defaults to 0.0.0.0:4319 when omitted.
+        #[arg(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+        otel_http_receiver_bind: ReceiverBindSetting,
+
+        /// Bind address for WuppieFuzz's built-in OTLP/gRPC receiver. Accepts IP:PORT, `off`, or `null`.
+        /// Defaults to the HTTP receiver IP at port 4317 when omitted.
+        #[arg(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+        otel_grpc_receiver_bind: ReceiverBindSetting,
     },
 }
 
@@ -320,6 +334,9 @@ impl Commands {
                 header,
                 log_level,
                 jacoco_class_prefix,
+                otel_receiver_bind,
+                otel_http_receiver_bind,
+                otel_grpc_receiver_bind,
                 ..
             } => Ok(PartialConfiguration {
                 openapi_spec,
@@ -340,6 +357,9 @@ impl Commands {
                 header,
                 log_level,
                 jacoco_class_prefix,
+                otel_receiver_bind,
+                otel_http_receiver_bind,
+                otel_grpc_receiver_bind,
             }),
             Commands::OutputCorpus {
                 corpus_directory: _,
@@ -463,6 +483,91 @@ struct PartialConfiguration {
     /// If no coverage is obtained anymore please check if the prefix is correct. If you use the trace debug level all skipped segment names are logged.
     #[clap(value_parser, long)]
     pub jacoco_class_prefix: Option<String>,
+
+    /// Legacy alias for otel_http_receiver_bind. Accepts IP:PORT, `off`, or `null`.
+    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+    #[serde(default)]
+    pub otel_receiver_bind: ReceiverBindSetting,
+
+    /// Bind address for WuppieFuzz's built-in OTLP/HTTP receiver. Accepts IP:PORT, `off`, or `null`.
+    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+    #[serde(default)]
+    pub otel_http_receiver_bind: ReceiverBindSetting,
+
+    /// Bind address for WuppieFuzz's built-in OTLP/gRPC receiver. Accepts IP:PORT, `off`, or `null`.
+    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+    #[serde(default)]
+    pub otel_grpc_receiver_bind: ReceiverBindSetting,
+}
+
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub enum ReceiverBindSetting {
+    #[default]
+    Unspecified,
+    Disabled,
+    Enabled(SocketAddr),
+}
+
+impl<'de> Deserialize<'de> for ReceiverBindSetting {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ReceiverBindVisitor;
+
+        impl<'de> de::Visitor<'de> for ReceiverBindVisitor {
+            type Value = ReceiverBindSetting;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a socket address, 'off', 'null', or null")
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(ReceiverBindSetting::Disabled)
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(ReceiverBindSetting::Disabled)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                parse_receiver_bind_setting(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(ReceiverBindVisitor)
+    }
+}
+
+fn receiver_bind_is_specified(setting: ReceiverBindSetting) -> bool {
+    !matches!(setting, ReceiverBindSetting::Unspecified)
+}
+
+fn prefer_receiver_bind(
+    preferred: ReceiverBindSetting,
+    fallback: ReceiverBindSetting,
+) -> ReceiverBindSetting {
+    if receiver_bind_is_specified(preferred) {
+        preferred
+    } else {
+        fallback
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum, Deserialize)]
@@ -473,6 +578,11 @@ pub enum CoverageFormat {
     Lcov,
     #[serde(alias = "coverband")]
     Coverband,
+    /// OpenTelemetry trace-based coverage: WuppieFuzz injects a W3C traceparent header
+    /// into every request, receives the resulting spans through its built-in OTLP/HTTP or
+    /// OTLP/gRPC receivers, and translates them into a coverage bitmap.
+    #[serde(alias = "otel")]
+    Otel,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum, Deserialize)]
@@ -579,6 +689,15 @@ pub enum CoverageConfiguration {
     },
     /// Coverband coverage. Requires a source directory if a report needs to be generated.
     Coverband { source_dir: Option<PathBuf> },
+    /// OpenTelemetry trace-based coverage. WuppieFuzz injects a W3C traceparent header
+    /// into every request, receives spans through its built-in OTLP/HTTP or OTLP/gRPC receivers, and
+    /// builds a span-presence + span-edge coverage bitmap.
+    Otel {
+        /// Bind address of WuppieFuzz's built-in OTLP/HTTP receiver, or None if disabled.
+        otel_http_receiver_bind: Option<SocketAddr>,
+        /// Bind address of WuppieFuzz's built-in OTLP/gRPC receiver, or None if disabled.
+        otel_grpc_receiver_bind: Option<SocketAddr>,
+    },
 }
 
 impl CoverageConfiguration {
@@ -588,6 +707,7 @@ impl CoverageConfiguration {
             Self::Lcov { .. } => "LCOV",
             Self::Jacoco { .. } => "JaCoCo",
             Self::Coverband { .. } => "Coverband",
+            Self::Otel { .. } => "OpenTelemetry",
         }
     }
 }
@@ -617,7 +737,14 @@ impl TryFrom<PartialConfiguration> for Configuration {
                     "A coverage report is requested for Jacoco coverage, but this requires the jacoco_class_dir parameter to be set",
                 );
             }
-            if value.coverage_format.is_some() && value.source_dir.is_none() {
+
+            if matches!(
+                value.coverage_format,
+                Some(CoverageFormat::Jacoco)
+                    | Some(CoverageFormat::Lcov)
+                    | Some(CoverageFormat::Coverband)
+            ) && value.source_dir.is_none()
+            {
                 bail!(
                     "A coverage report is requested, but this requires the source_dir parameter to be set",
                 );
@@ -645,6 +772,52 @@ impl TryFrom<PartialConfiguration> for Configuration {
                 Some(CoverageFormat::Coverband) => CoverageConfiguration::Coverband {
                     source_dir: value.source_dir,
                 },
+                Some(CoverageFormat::Otel) => {
+                    let default_http_bind = parse_socket_addr("0.0.0.0:4319")
+                        .expect("hardcoded OTLP/HTTP receiver bind address is valid");
+
+                    let configured_http =
+                        if receiver_bind_is_specified(value.otel_http_receiver_bind) {
+                            value.otel_http_receiver_bind
+                        } else {
+                            value.otel_receiver_bind
+                        };
+
+                    let otel_http_receiver_bind = match configured_http {
+                        ReceiverBindSetting::Unspecified => Some(default_http_bind),
+                        ReceiverBindSetting::Disabled => None,
+                        ReceiverBindSetting::Enabled(bind) => Some(bind),
+                    };
+
+                    let default_grpc_bind = otel_http_receiver_bind
+                        .map(|http_bind| {
+                            SocketAddr::new(
+                                http_bind.ip(),
+                                if http_bind.port() == 0 { 0 } else { 4317 },
+                            )
+                        })
+                        .unwrap_or_else(|| {
+                            parse_socket_addr("0.0.0.0:4317")
+                                .expect("hardcoded OTLP/gRPC receiver bind address is valid")
+                        });
+
+                    let otel_grpc_receiver_bind = match value.otel_grpc_receiver_bind {
+                        ReceiverBindSetting::Unspecified => Some(default_grpc_bind),
+                        ReceiverBindSetting::Disabled => None,
+                        ReceiverBindSetting::Enabled(bind) => Some(bind),
+                    };
+
+                    if otel_http_receiver_bind.is_none() && otel_grpc_receiver_bind.is_none() {
+                        bail!(
+                            "OpenTelemetry coverage requires at least one enabled OTLP receiver; set otel_http_receiver_bind or otel_grpc_receiver_bind to an IP:PORT"
+                        );
+                    }
+
+                    CoverageConfiguration::Otel {
+                        otel_http_receiver_bind,
+                        otel_grpc_receiver_bind,
+                    }
+                }
                 None => CoverageConfiguration::Endpoint,
             },
             timeout: value.timeout,
@@ -715,6 +888,18 @@ impl PartialConfiguration {
             jacoco_class_prefix: other
                 .jacoco_class_prefix
                 .or_else(|| self.jacoco_class_prefix.take()),
+            otel_receiver_bind: prefer_receiver_bind(
+                other.otel_receiver_bind,
+                self.otel_receiver_bind,
+            ),
+            otel_http_receiver_bind: prefer_receiver_bind(
+                other.otel_http_receiver_bind,
+                self.otel_http_receiver_bind,
+            ),
+            otel_grpc_receiver_bind: prefer_receiver_bind(
+                other.otel_grpc_receiver_bind,
+                self.otel_grpc_receiver_bind,
+            ),
         };
     }
 }
@@ -738,6 +923,14 @@ fn parse_socket_addr(arg: &str) -> Result<SocketAddr, io::Error> {
         ErrorKind::InvalidInput,
         "Could not parse socket address",
     ))
+}
+
+fn parse_receiver_bind_setting(arg: &str) -> Result<ReceiverBindSetting, io::Error> {
+    match arg.trim().to_ascii_lowercase().as_str() {
+        "" | "default" | "auto" => Ok(ReceiverBindSetting::Unspecified),
+        "off" | "none" | "null" | "disabled" | "false" => Ok(ReceiverBindSetting::Disabled),
+        _ => parse_socket_addr(arg).map(ReceiverBindSetting::Enabled),
+    }
 }
 
 fn verify_url(arg: &str) -> anyhow::Result<Url> {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -473,41 +473,6 @@ struct PartialConfiguration {
 
     // Manually added possible values below, since automatically showing possible values of an external (remote) enum
     // such as log::LevelFilter is not well supported.
-    // See https://github.com/serde-rs/serde/issues/1301, https://github.com/serde-rs/serde/issues/723
-    /// Log level to output. This flag takes precedence over the environment variable. [possible values: off, error, warn, debug, info, trace]
-    #[clap(value_parser = clap::value_parser!(log::LevelFilter), long, value_enum, env = "LOG_LEVEL", ignore_case = true)]
-    pub log_level: Option<log::LevelFilter>,
-
-    /// Prefix used to filter the classes returned from the jacoco coverage. The class name can be found in the source code of the software under test.
-    /// The class name returned from jacoco is in the form of "org/example/software/class".
-    /// If no coverage is obtained anymore please check if the prefix is correct. If you use the trace debug level all skipped segment names are logged.
-    #[clap(value_parser, long)]
-    pub jacoco_class_prefix: Option<String>,
-
-    /// Legacy alias for otel_http_receiver_bind. Accepts IP:PORT, `off`, or `null`.
-    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
-    #[serde(default)]
-    pub otel_receiver_bind: ReceiverBindSetting,
-
-    /// Bind address for WuppieFuzz's built-in OTLP/HTTP receiver. Accepts IP:PORT, `off`, or `null`.
-    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
-    #[serde(default)]
-    pub otel_http_receiver_bind: ReceiverBindSetting,
-
-    /// Bind address for WuppieFuzz's built-in OTLP/gRPC receiver. Accepts IP:PORT, `off`, or `null`.
-    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
-    #[serde(default)]
-    pub otel_grpc_receiver_bind: ReceiverBindSetting,
-}
-
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
-pub enum ReceiverBindSetting {
-    #[default]
-    Unspecified,
-    Disabled,
-    Enabled(SocketAddr),
-}
-
 impl<'de> Deserialize<'de> for ReceiverBindSetting {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -334,7 +334,6 @@ impl Commands {
                 header,
                 log_level,
                 jacoco_class_prefix,
-                otel_receiver_bind,
                 otel_http_receiver_bind,
                 otel_grpc_receiver_bind,
                 ..
@@ -357,7 +356,6 @@ impl Commands {
                 header,
                 log_level,
                 jacoco_class_prefix,
-                otel_receiver_bind,
                 otel_http_receiver_bind,
                 otel_grpc_receiver_bind,
             }),
@@ -483,11 +481,6 @@ struct PartialConfiguration {
     /// If no coverage is obtained anymore please check if the prefix is correct. If you use the trace debug level all skipped segment names are logged.
     #[clap(value_parser, long)]
     pub jacoco_class_prefix: Option<String>,
-
-    /// Legacy alias for otel_http_receiver_bind. Accepts IP:PORT, `off`, or `null`.
-    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
-    #[serde(default)]
-    pub otel_receiver_bind: ReceiverBindSetting,
 
     /// Bind address for WuppieFuzz's built-in OTLP/HTTP receiver. Accepts IP:PORT, `off`, or `null`.
     #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
@@ -741,14 +734,7 @@ impl TryFrom<PartialConfiguration> for Configuration {
                     let default_http_bind = parse_socket_addr("0.0.0.0:4319")
                         .expect("hardcoded OTLP/HTTP receiver bind address is valid");
 
-                    let configured_http =
-                        if receiver_bind_is_specified(value.otel_http_receiver_bind) {
-                            value.otel_http_receiver_bind
-                        } else {
-                            value.otel_receiver_bind
-                        };
-
-                    let otel_http_receiver_bind = match configured_http {
+                    let otel_http_receiver_bind = match value.otel_http_receiver_bind {
                         ReceiverBindSetting::Unspecified => Some(default_http_bind),
                         ReceiverBindSetting::Disabled => None,
                         ReceiverBindSetting::Enabled(bind) => Some(bind),
@@ -853,10 +839,6 @@ impl PartialConfiguration {
             jacoco_class_prefix: other
                 .jacoco_class_prefix
                 .or_else(|| self.jacoco_class_prefix.take()),
-            otel_receiver_bind: prefer_receiver_bind(
-                other.otel_receiver_bind,
-                self.otel_receiver_bind,
-            ),
             otel_http_receiver_bind: prefer_receiver_bind(
                 other.otel_http_receiver_bind,
                 self.otel_http_receiver_bind,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -473,6 +473,41 @@ struct PartialConfiguration {
 
     // Manually added possible values below, since automatically showing possible values of an external (remote) enum
     // such as log::LevelFilter is not well supported.
+    // See https://github.com/serde-rs/serde/issues/1301, https://github.com/serde-rs/serde/issues/723
+    /// Log level to output. This flag takes precedence over the environment variable. [possible values: off, error, warn, debug, info, trace]
+    #[clap(value_parser = clap::value_parser!(log::LevelFilter), long, value_enum, env = "LOG_LEVEL", ignore_case = true)]
+    pub log_level: Option<log::LevelFilter>,
+
+    /// Prefix used to filter the classes returned from the jacoco coverage. The class name can be found in the source code of the software under test.
+    /// The class name returned from jacoco is in the form of "org/example/software/class".
+    /// If no coverage is obtained anymore please check if the prefix is correct. If you use the trace debug level all skipped segment names are logged.
+    #[clap(value_parser, long)]
+    pub jacoco_class_prefix: Option<String>,
+
+    /// Legacy alias for otel_http_receiver_bind. Accepts IP:PORT, `off`, or `null`.
+    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+    #[serde(default)]
+    pub otel_receiver_bind: ReceiverBindSetting,
+
+    /// Bind address for WuppieFuzz's built-in OTLP/HTTP receiver. Accepts IP:PORT, `off`, or `null`.
+    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+    #[serde(default)]
+    pub otel_http_receiver_bind: ReceiverBindSetting,
+
+    /// Bind address for WuppieFuzz's built-in OTLP/gRPC receiver. Accepts IP:PORT, `off`, or `null`.
+    #[clap(value_parser = parse_receiver_bind_setting, long, default_value = "default")]
+    #[serde(default)]
+    pub otel_grpc_receiver_bind: ReceiverBindSetting,
+}
+
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub enum ReceiverBindSetting {
+    #[default]
+    Unspecified,
+    Disabled,
+    Enabled(SocketAddr),
+}
+
 impl<'de> Deserialize<'de> for ReceiverBindSetting {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,6 +1,6 @@
 use std::{
     convert::TryFrom,
-    fmt, io,
+    io,
     io::ErrorKind,
     net::{SocketAddr, ToSocketAddrs},
     path::{Path, PathBuf},
@@ -513,45 +513,10 @@ impl<'de> Deserialize<'de> for ReceiverBindSetting {
     where
         D: Deserializer<'de>,
     {
-        struct ReceiverBindVisitor;
-
-        impl<'de> de::Visitor<'de> for ReceiverBindVisitor {
-            type Value = ReceiverBindSetting;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("a socket address, 'off', 'null', or null")
-            }
-
-            fn visit_unit<E>(self) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(ReceiverBindSetting::Disabled)
-            }
-
-            fn visit_none<E>(self) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(ReceiverBindSetting::Disabled)
-            }
-
-            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                Deserialize::deserialize(deserializer)
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                parse_receiver_bind_setting(value).map_err(E::custom)
-            }
+        match Option::<String>::deserialize(deserializer)? {
+            None => Ok(Self::Disabled),
+            Some(value) => parse_receiver_bind_setting(&value).map_err(de::Error::custom),
         }
-
-        deserializer.deserialize_any(ReceiverBindVisitor)
     }
 }
 

--- a/src/coverage_clients/mod.rs
+++ b/src/coverage_clients/mod.rs
@@ -10,7 +10,10 @@ use std::{
 
 use anyhow::Context;
 
-use crate::configuration::{self, Configuration};
+use crate::{
+    configuration::{self, Configuration},
+    input::OpenApiInput,
+};
 
 /// Size of the coverage map. This is a bitmap containing a bit for each line in the target
 /// (or each endpoint, if using endpoint coverage as the guidance). The fuzzer will crash if
@@ -25,19 +28,26 @@ pub mod dummy;
 pub mod endpoint;
 pub mod jacoco;
 pub mod lcov_client;
+pub mod otel;
 
 /// Sets up the line coverage client according to the configuration, and initializes it
 /// and constructs a LibAFL observer and feedback
 pub fn setup_line_coverage(
     config: &'static Configuration,
     report_path: &Option<PathBuf>,
-) -> Result<Box<dyn CoverageClient>, anyhow::Error> {
-    let mut code_coverage_client: Box<dyn CoverageClient> =
+) -> Result<
+    (
+        Box<dyn CoverageClient>,
+        Option<otel::SharedOtelTraceProcessingMetrics>,
+    ),
+    anyhow::Error,
+> {
+    let (mut code_coverage_client, otel_trace_processing_metrics) =
         crate::coverage_clients::get_coverage_client(config, report_path)?;
-    // This is very important, we want to fetch and reset the coverage before interacting with the target
+    // This is very important, we want to fetch and reset the coverage before interacting with the target.
     code_coverage_client.fetch_coverage(true);
 
-    Ok(code_coverage_client)
+    Ok((code_coverage_client, otel_trace_processing_metrics))
 }
 
 /// APIs already create code coverage during boot. We check if the code coverage is non-zero.
@@ -46,7 +56,11 @@ pub fn validate_instrumentation(
     config: &'static Configuration,
     code_coverage_client: &mut Box<dyn CoverageClient>,
 ) {
-    if config.coverage_configuration != crate::configuration::CoverageConfiguration::Endpoint {
+    if !matches!(
+        config.coverage_configuration,
+        crate::configuration::CoverageConfiguration::Endpoint
+            | crate::configuration::CoverageConfiguration::Otel { .. }
+    ) {
         log::debug!("Gathering initial code coverage");
 
         match code_coverage_client.max_coverage_ratio() {
@@ -70,6 +84,32 @@ pub fn validate_instrumentation(
     }
 }
 
+/// Guidance that can promote inputs after the synchronous HTTP execution has returned.
+///
+/// OpenTelemetry spans are exported asynchronously, so the corresponding input can become
+/// interesting after normal LibAFL feedback has already been evaluated.
+pub trait DelayedGuidance {
+    /// Register that a new request sequence is about to be executed.
+    fn start_request_sequence(&mut self, input: &OpenApiInput);
+
+    /// Return the W3C trace context header value for the next outgoing HTTP request.
+    fn traceparent_for_request(&mut self) -> Option<String>;
+
+    /// Register that the current request sequence has finished executing.
+    fn finish_request_sequence(&mut self, input: &OpenApiInput);
+
+    /// Drain inputs that became interesting after asynchronous guidance arrived.
+    fn drain_promoted_inputs(&mut self) -> Vec<OpenApiInput>;
+
+    /// Enable or disable replay mode while delayed promotions are evaluated.
+    fn set_replaying_promotion(&mut self, replaying: bool);
+
+    /// Backwards-compatible spelling for callers that refer to replay promotion.
+    fn set_replay_promotion(&mut self, replaying: bool) {
+        self.set_replaying_promotion(replaying);
+    }
+}
+
 /// CoverageClient is a client (on the fuzzer side) responsible for communicating with the
 /// (coverage agent attached to the) program under test. It can be used to fetch the current
 /// code coverage bitmap.
@@ -77,6 +117,13 @@ pub trait CoverageClient {
     /// Fetch and process the current coverage. If `reset` is true, tells the remote
     /// coverage agent to reset its coverage map.
     fn fetch_coverage(&mut self, reset: bool);
+
+    /// Finish a request sequence. Synchronous coverage clients fetch coverage here;
+    /// asynchronous clients can override this to close their attribution window.
+    fn finish_request_sequence(&mut self, input: &OpenApiInput) {
+        let _ = input;
+        self.fetch_coverage(true);
+    }
 
     /// Retrieve a pointer to the coverage bitmap (this is used by LibAFL).
     fn get_coverage_ptr(&mut self) -> *mut u8;
@@ -91,6 +138,11 @@ pub trait CoverageClient {
 
     /// Write a format-dependent report to disk
     fn generate_coverage_report(&self, report_path: &Path);
+
+    /// Optional hook for delayed, asynchronous guidance sources such as OpenTelemetry.
+    fn delayed_guidance(&mut self) -> Option<&mut dyn DelayedGuidance> {
+        None
+    }
 }
 
 /// Returns the effective coverage host for the configured coverage format,
@@ -108,7 +160,8 @@ pub fn effective_coverage_host(config: &Configuration) -> Option<SocketAddr> {
                 .coverage_host
                 .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001)),
         ),
-        configuration::CoverageConfiguration::Endpoint => None,
+        configuration::CoverageConfiguration::Endpoint
+        | configuration::CoverageConfiguration::Otel { .. } => None,
     }
 }
 
@@ -116,47 +169,76 @@ pub fn effective_coverage_host(config: &Configuration) -> Option<SocketAddr> {
 pub fn get_coverage_client<'c>(
     clargs: &'c Configuration,
     report_path: &Option<PathBuf>,
-) -> Result<Box<dyn CoverageClient + 'c>, anyhow::Error> {
+) -> Result<
+    (
+        Box<dyn CoverageClient + 'c>,
+        Option<otel::SharedOtelTraceProcessingMetrics>,
+    ),
+    anyhow::Error,
+> {
     let coverage_host = effective_coverage_host(clargs);
 
     Ok(match clargs.coverage_configuration {
         configuration::CoverageConfiguration::Jacoco {
             ref jacoco_class_prefix,
             ..
-        } => Box::new(
-            jacoco::JacocoCoverageClient::new(
-                // effective_coverage_host always returns Some for Jacoco
-                &coverage_host.unwrap(),
-                report_path
-                    .clone()
-                    .map(|report_path| report_path.as_path().join("jacoco_exec")),
-                jacoco_class_prefix,
-            )
-            .context("Could not construct JacocoCoverageClient")?,
+        } => (
+            Box::new(
+                jacoco::JacocoCoverageClient::new(
+                    // effective_coverage_host always returns Some for Jacoco
+                    &coverage_host.unwrap(),
+                    report_path
+                        .clone()
+                        .map(|report_path| report_path.as_path().join("jacoco_exec")),
+                    jacoco_class_prefix,
+                )
+                .context("Could not construct JacocoCoverageClient")?,
+            ),
+            None,
         ),
-        configuration::CoverageConfiguration::Lcov { .. } => Box::new(
-            lcov_client::LcovCoverageClient::new(
-                // effective_coverage_host always returns Some for Lcov
-                &coverage_host.unwrap(),
-                report_path
-                    .clone()
-                    .map(|report_path| report_path.as_path().join("lcov_exec")),
-            )
-            .context("Could not construct LcovCoverageClient")?,
+        configuration::CoverageConfiguration::Lcov { .. } => (
+            Box::new(
+                lcov_client::LcovCoverageClient::new(
+                    // effective_coverage_host always returns Some for Lcov
+                    &coverage_host.unwrap(),
+                    report_path
+                        .clone()
+                        .map(|report_path| report_path.as_path().join("lcov_exec")),
+                )
+                .context("Could not construct LcovCoverageClient")?,
+            ),
+            None,
         ),
         configuration::CoverageConfiguration::Coverband { .. } => {
             // effective_coverage_host always returns Some for Coverband
             let mut url = coverage_host.unwrap().to_string();
             url.insert_str(0, "https://");
-            Box::new(coverband::CoverbandCoverageClient::new(
-                url.as_str()
-                    .try_into()
-                    .with_context(|| format!("Failed to parse the coverage_host URL: {url}"))
-                    .context("Could not construct CoverbandCoverageClient")?,
-            ))
+            (
+                Box::new(coverband::CoverbandCoverageClient::new(
+                    url.as_str()
+                        .try_into()
+                        .with_context(|| format!("Failed to parse the coverage_host URL: {url}"))
+                        .context("Could not construct CoverbandCoverageClient")?,
+                )),
+                None,
+            )
         }
         configuration::CoverageConfiguration::Endpoint => {
-            Box::new(dummy::DummyCoverageClient::new())
+            (Box::new(dummy::DummyCoverageClient::new()), None)
+        }
+        configuration::CoverageConfiguration::Otel {
+            otel_http_receiver_bind,
+            otel_grpc_receiver_bind,
+        } => {
+            let otel_trace_processing_metrics = otel::new_otel_trace_processing_metrics();
+            (
+                Box::new(otel::OtelCoverageClient::new(
+                    otel_http_receiver_bind,
+                    otel_grpc_receiver_bind,
+                    otel_trace_processing_metrics.clone(),
+                )?),
+                Some(otel_trace_processing_metrics),
+            )
         }
     })
 }

--- a/src/coverage_clients/otel/arbiter.rs
+++ b/src/coverage_clients/otel/arbiter.rs
@@ -1,0 +1,242 @@
+use std::sync::mpsc::Sender;
+
+use tokio::{sync::watch, time};
+
+use super::{
+    coverage::SharedCoverageState,
+    trace_store::{TraceStore, TraceStoreEvent},
+    types::{
+        ArbiterMessage, DEFAULT_ARBITER_TICK_INTERVAL, DEFAULT_MAX_ACTIVE_SEQUENCES,
+        DEFAULT_SEQUENCE_RETENTION_WINDOW, PromotionCandidate, SharedOtelTraceProcessingMetrics,
+        record_engine_queue_depth,
+    },
+};
+
+fn process_resolutions(
+    metrics: &SharedOtelTraceProcessingMetrics,
+    promotion_tx: &Sender<PromotionCandidate>,
+    events: Vec<TraceStoreEvent>,
+) -> bool {
+    for event in events {
+        match event {
+            TraceStoreEvent::RequestRootRegistered => {
+                let mut shared_metrics = metrics
+                    .lock()
+                    .expect("otel trace processing metrics mutex poisoned");
+                shared_metrics.sequence_roots_expected =
+                    shared_metrics.sequence_roots_expected.saturating_add(1);
+            }
+            TraceStoreEvent::RequestRootUnknownTrace => {
+                let mut shared_metrics = metrics
+                    .lock()
+                    .expect("otel trace processing metrics mutex poisoned");
+                shared_metrics.request_roots_unknown_trace =
+                    shared_metrics.request_roots_unknown_trace.saturating_add(1);
+            }
+            TraceStoreEvent::SequenceFinishUnknownTrace => {
+                let mut shared_metrics = metrics
+                    .lock()
+                    .expect("otel trace processing metrics mutex poisoned");
+                shared_metrics.sequence_finish_unknown_trace = shared_metrics
+                    .sequence_finish_unknown_trace
+                    .saturating_add(1);
+            }
+            TraceStoreEvent::LateAfterEviction => {
+                let mut shared_metrics = metrics
+                    .lock()
+                    .expect("otel trace processing metrics mutex poisoned");
+                shared_metrics.spans_late_after_eviction =
+                    shared_metrics.spans_late_after_eviction.saturating_add(1);
+            }
+            TraceStoreEvent::RootSeen => {
+                let mut shared_metrics = metrics
+                    .lock()
+                    .expect("otel trace processing metrics mutex poisoned");
+                shared_metrics.sequence_roots_seen =
+                    shared_metrics.sequence_roots_seen.saturating_add(1);
+            }
+            TraceStoreEvent::Promotion {
+                trace_id,
+                candidate,
+                ..
+            } => {
+                {
+                    let mut shared_metrics = metrics
+                        .lock()
+                        .expect("otel trace processing metrics mutex poisoned");
+                    shared_metrics.sequences_promoted =
+                        shared_metrics.sequences_promoted.saturating_add(1);
+                }
+
+                log::debug!(
+                    "OTel arbiter marked sequence submission {} for trace {} as novel",
+                    candidate.submission_id,
+                    trace_id
+                );
+
+                if promotion_tx.send(candidate).is_err() {
+                    log::warn!(
+                        "OTel promotion channel disconnected; delayed OTel seed promotion is unavailable"
+                    );
+                    return false;
+                }
+            }
+            TraceStoreEvent::Evicted {
+                trace_id,
+                expected_parent_ids,
+                seen_parent_ids,
+                lifetime,
+                was_novel,
+                reason,
+            } => {
+                log::debug!(
+                    "OTel sequence {trace_id} evicted after {:?}: saw {seen_parent_ids}/{expected_parent_ids} registered request roots, novel={was_novel}, reason={reason:?}",
+                    lifetime
+                );
+            }
+            TraceStoreEvent::NonNovel {
+                trace_id,
+                expected_parent_ids,
+                seen_parent_ids,
+            } => {
+                log::debug!(
+                    "OTel sequence {trace_id} evicted without new coverage after seeing {seen_parent_ids}/{expected_parent_ids} registered request roots"
+                );
+            }
+            TraceStoreEvent::Dropped {
+                trace_id,
+                expected_parent_ids,
+                seen_parent_ids,
+                waited,
+            } => {
+                log::debug!(
+                    "OTel sequence {trace_id} evicted after {:?} without spans: saw {seen_parent_ids}/{expected_parent_ids} registered request roots",
+                    waited
+                );
+            }
+            TraceStoreEvent::SequenceStarted
+            | TraceStoreEvent::SequenceFinished
+            | TraceStoreEvent::DuplicateSequenceStart
+            | TraceStoreEvent::RequestRootRegisteredAfterSpan
+            | TraceStoreEvent::OrphanSpan
+            | TraceStoreEvent::OrphanSpanBuffered
+            | TraceStoreEvent::OrphanSpanReassociated
+            | TraceStoreEvent::OrphanSpanExpired
+            | TraceStoreEvent::OrphanSpanCapacityDropped => {}
+        }
+    }
+
+    true
+}
+
+struct TraceStateSnapshot {
+    unique_span_keys: usize,
+    unique_edge_keys: usize,
+}
+
+fn update_trace_state_metrics(
+    metrics: &SharedOtelTraceProcessingMetrics,
+    snapshot: TraceStateSnapshot,
+) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    metrics.unique_span_keys = snapshot.unique_span_keys as u64;
+    metrics.unique_edge_keys = snapshot.unique_edge_keys as u64;
+}
+
+pub(crate) async fn run_otel_arbiter(
+    coverage_state: SharedCoverageState,
+    metrics: SharedOtelTraceProcessingMetrics,
+    mut job_rx: tokio::sync::mpsc::Receiver<ArbiterMessage>,
+    promotion_tx: Sender<PromotionCandidate>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let mut trace_store = TraceStore::default();
+    let mut tick = time::interval(DEFAULT_ARBITER_TICK_INTERVAL);
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => break,
+            message = job_rx.recv() => {
+                let Some(message) = message else {
+                    log::warn!("OTel arbiter input channel disconnected; delayed OTel promotion will stop");
+                    break;
+                };
+
+                match message {
+                    ArbiterMessage::SequenceStarted {
+                        submission_id,
+                        input,
+                        trace_id,
+                    } => {
+                        let events = {
+                            let mut coverage_state = coverage_state
+                                .lock()
+                                .expect("otel coverage state mutex poisoned");
+                            trace_store.start_sequence(trace_id, submission_id, input, &mut coverage_state)
+                        };
+                        if !process_resolutions(&metrics, &promotion_tx, events) {
+                            break;
+                        }
+                    }
+                    ArbiterMessage::RequestRootRegistered {
+                        trace_id,
+                        parent_id,
+                    } => {
+                        let events = trace_store.register_request_root(trace_id, parent_id);
+                        if !process_resolutions(&metrics, &promotion_tx, events) {
+                            break;
+                        }
+                    }
+                    ArbiterMessage::SequenceFinished {
+                        trace_id,
+                    } => {
+                        let events = trace_store.finish_sequence(trace_id);
+                        if !process_resolutions(&metrics, &promotion_tx, events) {
+                            break;
+                        }
+                    }
+                    ArbiterMessage::ReceivedSpans(spans) => {
+                        let events = {
+                            let mut coverage_state = coverage_state
+                                .lock()
+                                .expect("otel coverage state mutex poisoned");
+                            trace_store.ingest_spans(spans, &mut coverage_state)
+                        };
+                        if !process_resolutions(&metrics, &promotion_tx, events) {
+                            break;
+                        }
+                    }
+                    ArbiterMessage::Shutdown => break,
+                }
+                record_engine_queue_depth(&metrics, job_rx.len());
+            }
+            _ = tick.tick() => {}
+        }
+
+        let events = trace_store.drain_timeouts(
+            DEFAULT_SEQUENCE_RETENTION_WINDOW,
+            DEFAULT_MAX_ACTIVE_SEQUENCES,
+        );
+        if !process_resolutions(&metrics, &promotion_tx, events) {
+            break;
+        }
+        let (unique_span_keys, unique_edge_keys) = {
+            let coverage_state = coverage_state
+                .lock()
+                .expect("otel coverage state mutex poisoned");
+            (
+                coverage_state.span_key_count(),
+                coverage_state.edge_key_count(),
+            )
+        };
+        update_trace_state_metrics(
+            &metrics,
+            TraceStateSnapshot {
+                unique_span_keys,
+                unique_edge_keys,
+            },
+        );
+    }
+}

--- a/src/coverage_clients/otel/arbiter.rs
+++ b/src/coverage_clients/otel/arbiter.rs
@@ -1,3 +1,7 @@
+//! The async arbiter task: owns the [`TraceStore`](super::trace_store::TraceStore), applies
+//! incoming spans to the shared coverage bitmap, and promotes sequences that produced novel
+//! coverage back to the fuzzer.
+
 use std::sync::mpsc::Sender;
 
 use tokio::{sync::watch, time};

--- a/src/coverage_clients/otel/client.rs
+++ b/src/coverage_clients/otel/client.rs
@@ -1,3 +1,7 @@
+//! The [`CoverageClient`] implementation for OTel-based coverage: injects trace context into
+//! outgoing requests, drives the built-in OTLP receiver/arbiter, and reports coverage derived
+//! from spans back to the fuzzer via [`DelayedGuidance`].
+
 use std::{
     net::SocketAddr,
     path::Path,

--- a/src/coverage_clients/otel/client.rs
+++ b/src/coverage_clients/otel/client.rs
@@ -1,0 +1,456 @@
+use std::{
+    net::SocketAddr,
+    path::Path,
+    sync::mpsc::{self, Receiver},
+};
+
+use anyhow::Context;
+use rand::RngExt;
+use tokio::sync::mpsc::{Sender, error::TrySendError};
+
+use crate::{
+    coverage_clients::{CoverageClient, DelayedGuidance},
+    input::OpenApiInput,
+};
+
+use super::{
+    coverage::{SharedCoverageState, new_shared_coverage_state},
+    receiver::{OtelReceiverHandle, start_otel_receiver},
+    types::{
+        ArbiterMessage, PromotionCandidate, SharedOtelTraceProcessingMetrics,
+        record_engine_backpressure, record_engine_queue_depth,
+    },
+};
+
+fn random_trace_id() -> String {
+    let mut rng = rand::rng();
+    loop {
+        let trace_hi: u64 = rng.random();
+        let trace_lo: u64 = rng.random();
+        if trace_hi != 0 || trace_lo != 0 {
+            return format!("{trace_hi:016x}{trace_lo:016x}");
+        }
+    }
+}
+
+fn random_span_id() -> String {
+    let mut rng = rand::rng();
+    loop {
+        let span_id: u64 = rng.random();
+        if span_id != 0 {
+            return format!("{span_id:016x}");
+        }
+    }
+}
+
+fn send_arbiter_message(
+    job_tx: &Sender<ArbiterMessage>,
+    metrics: &SharedOtelTraceProcessingMetrics,
+    message: ArbiterMessage,
+    description: &str,
+) -> Result<(), ()> {
+    match job_tx.try_send(message) {
+        Ok(()) => {
+            record_engine_queue_depth(metrics, job_tx.max_capacity() - job_tx.capacity());
+            Ok(())
+        }
+        Err(TrySendError::Full(message)) => {
+            log::warn!(
+                "OTel arbiter queue is saturated while sending {description}; applying backpressure until the arbiter catches up"
+            );
+            record_engine_backpressure(metrics);
+            job_tx.blocking_send(message).map_err(|error| {
+                log::warn!(
+                    "OTel arbiter queue disconnected while sending {description}; delayed OTel guidance is disabled: {error}"
+                );
+            })?;
+            record_engine_queue_depth(metrics, job_tx.max_capacity() - job_tx.capacity());
+            Ok(())
+        }
+        Err(TrySendError::Closed(_)) => {
+            log::warn!(
+                "OTel arbiter queue disconnected while sending {description}; delayed OTel guidance is disabled"
+            );
+            Err(())
+        }
+    }
+}
+
+/// Coverage client that turns OTLP-received OTel spans into delayed seed promotions.
+pub struct OtelCoverageClient {
+    current_trace_id: Option<String>,
+    otel_http_receiver_bind: Option<SocketAddr>,
+    otel_grpc_receiver_bind: Option<SocketAddr>,
+    coverage_state: SharedCoverageState,
+    trace_processing_metrics: SharedOtelTraceProcessingMetrics,
+    job_tx: Sender<ArbiterMessage>,
+    promotion_rx: Receiver<PromotionCandidate>,
+    next_submission_id: u64,
+    replaying_promotion: bool,
+    guidance_enabled: bool,
+    _receiver_handle: OtelReceiverHandle,
+    dummy_cov_map: Box<[u8; 1]>,
+}
+
+impl OtelCoverageClient {
+    /// Create a new OTel coverage client backed by the built-in OTLP receivers.
+    pub fn new(
+        otel_http_receiver_bind: Option<SocketAddr>,
+        otel_grpc_receiver_bind: Option<SocketAddr>,
+        trace_processing_metrics: SharedOtelTraceProcessingMetrics,
+    ) -> anyhow::Result<Self> {
+        let coverage_state = new_shared_coverage_state();
+        let (promotion_tx, promotion_rx) = mpsc::channel();
+
+        let receiver_handle = start_otel_receiver(
+            otel_http_receiver_bind,
+            otel_grpc_receiver_bind,
+            coverage_state.clone(),
+            trace_processing_metrics.clone(),
+            promotion_tx,
+        )
+        .context("failed to start OTLP receiver")?;
+        let job_tx = receiver_handle.job_tx();
+
+        Ok(Self {
+            current_trace_id: None,
+            otel_http_receiver_bind,
+            otel_grpc_receiver_bind,
+            coverage_state,
+            trace_processing_metrics,
+            job_tx,
+            promotion_rx,
+            next_submission_id: 0,
+            replaying_promotion: false,
+            guidance_enabled: true,
+            _receiver_handle: receiver_handle,
+            dummy_cov_map: Box::new([0u8; 1]),
+        })
+    }
+
+    #[cfg(test)]
+    fn new_for_tests() -> Self {
+        let trace_processing_metrics = super::new_otel_trace_processing_metrics();
+        let coverage_state = new_shared_coverage_state();
+        let (promotion_tx, promotion_rx) = mpsc::channel();
+        let receiver_handle = start_otel_receiver(
+            Some("127.0.0.1:0".parse().unwrap()),
+            Some("127.0.0.1:0".parse().unwrap()),
+            coverage_state.clone(),
+            trace_processing_metrics.clone(),
+            promotion_tx,
+        )
+        .expect("test OTLP receiver should start");
+        let job_tx = receiver_handle.job_tx();
+
+        Self {
+            current_trace_id: None,
+            otel_http_receiver_bind: Some("127.0.0.1:0".parse().unwrap()),
+            otel_grpc_receiver_bind: Some("127.0.0.1:0".parse().unwrap()),
+            coverage_state,
+            trace_processing_metrics,
+            job_tx,
+            promotion_rx,
+            next_submission_id: 0,
+            replaying_promotion: false,
+            guidance_enabled: true,
+            _receiver_handle: receiver_handle,
+            dummy_cov_map: Box::new([0u8; 1]),
+        }
+    }
+
+    fn clear_current_sequence(&mut self) {
+        self.current_trace_id = None;
+    }
+
+    fn start_sequence_with_input(&mut self, input: &OpenApiInput) -> Option<String> {
+        if self.replaying_promotion || !self.guidance_enabled {
+            return None;
+        }
+
+        if let Some(trace_id) = &self.current_trace_id {
+            return Some(trace_id.clone());
+        }
+
+        let submission_id = self.next_submission_id;
+        self.next_submission_id = self.next_submission_id.saturating_add(1);
+
+        let trace_id = random_trace_id();
+        if send_arbiter_message(
+            &self.job_tx,
+            &self.trace_processing_metrics,
+            ArbiterMessage::SequenceStarted {
+                submission_id,
+                input: input.clone(),
+                trace_id: trace_id.clone(),
+            },
+            "OTel sequence start",
+        )
+        .is_err()
+        {
+            self.guidance_enabled = false;
+            self.clear_current_sequence();
+            return None;
+        }
+
+        self.current_trace_id = Some(trace_id.clone());
+        Some(trace_id)
+    }
+}
+
+impl CoverageClient for OtelCoverageClient {
+    fn fetch_coverage(&mut self, _reset: bool) {}
+
+    fn finish_request_sequence(&mut self, input: &OpenApiInput) {
+        <Self as DelayedGuidance>::finish_request_sequence(self, input);
+    }
+
+    fn get_coverage_ptr(&mut self) -> *mut u8 {
+        self.dummy_cov_map.as_mut_ptr()
+    }
+
+    fn get_coverage_len(&self) -> usize {
+        0
+    }
+
+    fn max_coverage_ratio(&mut self) -> (u64, u64) {
+        self.coverage_state
+            .lock()
+            .expect("otel coverage state mutex poisoned")
+            .coverage_ratio()
+    }
+
+    fn generate_coverage_report(&self, report_path: &Path) {
+        use std::fmt::Write;
+
+        let state = self
+            .coverage_state
+            .lock()
+            .expect("otel coverage state mutex poisoned");
+
+        let mut out = String::new();
+        writeln!(out, "OTel Coverage Report").ok();
+        writeln!(out, "====================").ok();
+        writeln!(
+            out,
+            "OTLP/HTTP receiver: {}",
+            self.otel_http_receiver_bind
+                .map(|bind| bind.to_string())
+                .unwrap_or_else(|| "disabled".to_owned())
+        )
+        .ok();
+        writeln!(
+            out,
+            "OTLP/gRPC receiver: {}",
+            self.otel_grpc_receiver_bind
+                .map(|bind| bind.to_string())
+                .unwrap_or_else(|| "disabled".to_owned())
+        )
+        .ok();
+        writeln!(out, "Unique span types  : {}", state.span_names.len()).ok();
+        writeln!(out, "Unique span edges  : {}", state.edge_names.len()).ok();
+        writeln!(out).ok();
+
+        writeln!(out, "Span types (service [kind] operation):").ok();
+        for span in &state.span_names {
+            writeln!(out, "  {}", span.display()).ok();
+        }
+
+        writeln!(out).ok();
+        writeln!(out, "Span edges (parent -> child):").ok();
+        for edge in &state.edge_names {
+            writeln!(
+                out,
+                "  {}  ->  {}",
+                edge.parent.display(),
+                edge.child.display()
+            )
+            .ok();
+        }
+
+        let file_path = report_path.join("otel_coverage.txt");
+        if let Err(error) = std::fs::write(&file_path, out.as_bytes()) {
+            log::error!("Failed to write OTel coverage report to {file_path:?}: {error}");
+        } else {
+            log::info!("OTel coverage report written to {file_path:?}");
+        }
+    }
+
+    fn delayed_guidance(&mut self) -> Option<&mut dyn DelayedGuidance> {
+        Some(self)
+    }
+}
+
+impl DelayedGuidance for OtelCoverageClient {
+    fn start_request_sequence(&mut self, input: &OpenApiInput) {
+        self.start_sequence_with_input(input);
+    }
+
+    fn traceparent_for_request(&mut self) -> Option<String> {
+        if self.replaying_promotion || !self.guidance_enabled {
+            return None;
+        }
+
+        let trace_id = self
+            .current_trace_id
+            .clone()
+            .or_else(|| self.start_sequence_with_input(&OpenApiInput(Vec::new())))?;
+        let parent_id = random_span_id();
+
+        if send_arbiter_message(
+            &self.job_tx,
+            &self.trace_processing_metrics,
+            ArbiterMessage::RequestRootRegistered {
+                trace_id: trace_id.clone(),
+                parent_id: parent_id.clone(),
+            },
+            "OTel request root registration",
+        )
+        .is_err()
+        {
+            self.guidance_enabled = false;
+            self.clear_current_sequence();
+            return None;
+        }
+
+        let traceparent = format!("00-{trace_id}-{parent_id}-01");
+        log::trace!("Injecting sequence-scoped traceparent: {traceparent}");
+        Some(traceparent)
+    }
+
+    fn finish_request_sequence(&mut self, input: &OpenApiInput) {
+        let _ = input;
+        if self.replaying_promotion {
+            self.clear_current_sequence();
+            return;
+        }
+
+        let Some(trace_id) = self.current_trace_id.take() else {
+            return;
+        };
+
+        if !self.guidance_enabled {
+            return;
+        }
+
+        if send_arbiter_message(
+            &self.job_tx,
+            &self.trace_processing_metrics,
+            ArbiterMessage::SequenceFinished { trace_id },
+            "OTel sequence finish",
+        )
+        .is_err()
+        {
+            self.guidance_enabled = false;
+        }
+    }
+
+    fn drain_promoted_inputs(&mut self) -> Vec<OpenApiInput> {
+        let mut promoted = Vec::new();
+        while let Ok(candidate) = self.promotion_rx.try_recv() {
+            log::debug!(
+                "Drained delayed OTel promotion candidate {}",
+                candidate.submission_id
+            );
+            promoted.push(candidate.input);
+        }
+        promoted
+    }
+
+    fn set_replaying_promotion(&mut self, replaying: bool) {
+        self.replaying_promotion = replaying;
+        if replaying {
+            self.clear_current_sequence();
+        }
+    }
+}
+
+impl Drop for OtelCoverageClient {
+    fn drop(&mut self) {
+        match self.job_tx.try_send(ArbiterMessage::Shutdown) {
+            Ok(()) | Err(TrySendError::Closed(_)) => {}
+            Err(TrySendError::Full(message)) => {
+                let _ = self.job_tx.blocking_send(message);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::coverage_clients::{CoverageClient, DelayedGuidance};
+
+    use super::OtelCoverageClient;
+
+    fn make_client() -> OtelCoverageClient {
+        OtelCoverageClient::new_for_tests()
+    }
+
+    #[test]
+    fn traceparent_returns_some() {
+        let mut client = make_client();
+        assert!(client.traceparent_for_request().is_some());
+    }
+
+    #[test]
+    fn traceparent_format_matches_w3c_spec() {
+        let mut client = make_client();
+        let traceparent = client.traceparent_for_request().unwrap();
+        let parts: Vec<&str> = traceparent.split('-').collect();
+
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0], "00");
+        assert_eq!(parts[1].len(), 32);
+        assert_eq!(parts[2].len(), 16);
+        assert_eq!(parts[3], "01");
+    }
+
+    #[test]
+    fn traceparent_reuses_trace_id_within_sequence_but_changes_parent_id() {
+        let mut client = make_client();
+        let first = client.traceparent_for_request().unwrap();
+        let second = client.traceparent_for_request().unwrap();
+
+        let first_parts: Vec<&str> = first.split('-').collect();
+        let second_parts: Vec<&str> = second.split('-').collect();
+        assert_eq!(first_parts[1], second_parts[1]);
+        assert_ne!(first_parts[2], second_parts[2]);
+    }
+
+    #[test]
+    fn finish_request_sequence_resets_trace_id_for_next_sequence() {
+        let mut client = make_client();
+        let first = client.traceparent_for_request().unwrap();
+        DelayedGuidance::finish_request_sequence(&mut client, &crate::input::OpenApiInput(vec![]));
+        let second = client.traceparent_for_request().unwrap();
+
+        let first_trace_id = first.split('-').nth(1).unwrap();
+        let second_trace_id = second.split('-').nth(1).unwrap();
+        assert_ne!(first_trace_id, second_trace_id);
+    }
+
+    #[test]
+    fn coverage_client_finish_request_sequence_resets_trace_id_for_next_sequence() {
+        let mut client = make_client();
+        let first = client.traceparent_for_request().unwrap();
+        CoverageClient::finish_request_sequence(&mut client, &crate::input::OpenApiInput(vec![]));
+        let second = client.traceparent_for_request().unwrap();
+
+        let first_trace_id = first.split('-').nth(1).unwrap();
+        let second_trace_id = second.split('-').nth(1).unwrap();
+        assert_ne!(first_trace_id, second_trace_id);
+    }
+
+    #[test]
+    fn replay_mode_disables_traceparent_injection() {
+        let mut client = make_client();
+        client.set_replaying_promotion(true);
+        assert!(client.traceparent_for_request().is_none());
+    }
+
+    #[test]
+    fn live_coverage_len_is_zero() {
+        let client = make_client();
+        assert_eq!(client.get_coverage_len(), 0);
+    }
+}

--- a/src/coverage_clients/otel/client.rs
+++ b/src/coverage_clients/otel/client.rs
@@ -12,11 +12,6 @@ use anyhow::Context;
 use rand::RngExt;
 use tokio::sync::mpsc::{Sender, error::TrySendError};
 
-use crate::{
-    coverage_clients::{CoverageClient, DelayedGuidance},
-    input::OpenApiInput,
-};
-
 use super::{
     coverage::{SharedCoverageState, new_shared_coverage_state},
     receiver::{OtelReceiverHandle, start_otel_receiver},
@@ -24,6 +19,10 @@ use super::{
         ArbiterMessage, PromotionCandidate, SharedOtelTraceProcessingMetrics,
         record_engine_backpressure, record_engine_queue_depth,
     },
+};
+use crate::{
+    coverage_clients::{CoverageClient, DelayedGuidance},
+    input::OpenApiInput,
 };
 
 fn random_trace_id() -> String {
@@ -382,9 +381,8 @@ impl Drop for OtelCoverageClient {
 
 #[cfg(test)]
 mod tests {
-    use crate::coverage_clients::{CoverageClient, DelayedGuidance};
-
     use super::OtelCoverageClient;
+    use crate::coverage_clients::{CoverageClient, DelayedGuidance};
 
     fn make_client() -> OtelCoverageClient {
         OtelCoverageClient::new_for_tests()

--- a/src/coverage_clients/otel/coverage.rs
+++ b/src/coverage_clients/otel/coverage.rs
@@ -1,3 +1,6 @@
+//! Translates OTel spans into the shared coverage bitmap: distinct span types and
+//! parent/child span edges are each assigned a bit, discovered on first sight.
+
 use std::{
     collections::{HashMap, hash_map::Entry},
     sync::{Arc, Mutex},

--- a/src/coverage_clients/otel/coverage.rs
+++ b/src/coverage_clients/otel/coverage.rs
@@ -6,9 +6,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::coverage_clients::MAP_SIZE;
-
 use super::types::{OtelSpanKind, ParsedSpan};
+use crate::coverage_clients::MAP_SIZE;
 
 pub(crate) type SharedCoverageState = Arc<Mutex<OtelCoverageState>>;
 

--- a/src/coverage_clients/otel/coverage.rs
+++ b/src/coverage_clients/otel/coverage.rs
@@ -1,0 +1,360 @@
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    sync::{Arc, Mutex},
+};
+
+use crate::coverage_clients::MAP_SIZE;
+
+use super::types::{OtelSpanKind, ParsedSpan};
+
+pub(crate) type SharedCoverageState = Arc<Mutex<OtelCoverageState>>;
+
+pub(crate) fn new_shared_coverage_state() -> SharedCoverageState {
+    Arc::new(Mutex::new(OtelCoverageState::default()))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SpanKey {
+    pub(crate) service_namespace: Option<String>,
+    pub(crate) service: String,
+    pub(crate) kind: OtelSpanKind,
+    pub(crate) operation: String,
+}
+
+impl SpanKey {
+    pub(crate) fn from_span(span: &ParsedSpan) -> Self {
+        Self {
+            service_namespace: span.service_namespace.clone(),
+            service: span.service.clone(),
+            kind: span.kind,
+            operation: normalized_operation(span),
+        }
+    }
+
+    pub(crate) fn display(&self) -> String {
+        let service = match &self.service_namespace {
+            Some(namespace) if !namespace.is_empty() => {
+                format!("{namespace}/{}", self.service)
+            }
+            _ => self.service.clone(),
+        };
+        format!("{} [{}] {}", service, self.kind.as_str(), self.operation)
+    }
+}
+
+fn normalized_operation(span: &ParsedSpan) -> String {
+    if let Some(method) = span
+        .rpc_method
+        .as_deref()
+        .filter(|method| !method.is_empty())
+    {
+        return match span
+            .rpc_system_name
+            .as_deref()
+            .filter(|system| !system.is_empty())
+        {
+            Some(system) => format!("RPC {system} {method}"),
+            None => format!("RPC {method}"),
+        };
+    }
+
+    if let Some(method) = span
+        .http_request_method
+        .as_deref()
+        .filter(|method| !method.is_empty())
+    {
+        if span.kind == OtelSpanKind::Server {
+            return match span.http_route.as_deref().filter(|route| !route.is_empty()) {
+                Some(route) => format!("HTTP {method} {route}"),
+                None => format!("HTTP {method}"),
+            };
+        }
+
+        if span.kind == OtelSpanKind::Client {
+            return match span
+                .url_template
+                .as_deref()
+                .filter(|template| !template.is_empty())
+            {
+                Some(template) => format!("HTTP {method} {template}"),
+                None => format!("HTTP {method}"),
+            };
+        }
+
+        if let Some(route) = span.http_route.as_deref().filter(|route| !route.is_empty()) {
+            return format!("HTTP {method} {route}");
+        }
+
+        if let Some(template) = span
+            .url_template
+            .as_deref()
+            .filter(|template| !template.is_empty())
+        {
+            return format!("HTTP {method} {template}");
+        }
+
+        return format!("HTTP {method}");
+    }
+
+    if span.name.is_empty() {
+        "unknown_operation".to_owned()
+    } else {
+        span.name.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct EdgeKey {
+    pub(crate) parent: SpanKey,
+    pub(crate) child: SpanKey,
+}
+
+impl EdgeKey {
+    pub(crate) fn new(parent: SpanKey, child: SpanKey) -> Self {
+        Self { parent, child }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct OtelCoverageState {
+    cov_map: Box<[u8; 2 * MAP_SIZE]>,
+    span_index: HashMap<SpanKey, usize>,
+    first_unused_span_idx: usize,
+    pub(crate) span_names: Vec<SpanKey>,
+    edge_index: HashMap<EdgeKey, usize>,
+    first_unused_edge_idx: usize,
+    pub(crate) edge_names: Vec<EdgeKey>,
+}
+
+impl Default for OtelCoverageState {
+    fn default() -> Self {
+        Self {
+            cov_map: Box::new([0u8; 2 * MAP_SIZE]),
+            span_index: HashMap::new(),
+            first_unused_span_idx: 0,
+            span_names: Vec::new(),
+            edge_index: HashMap::new(),
+            first_unused_edge_idx: 0,
+            edge_names: Vec::new(),
+        }
+    }
+}
+
+impl OtelCoverageState {
+    fn get_or_assign_span_idx(&mut self, key: SpanKey) -> (Option<usize>, bool) {
+        match self.span_index.entry(key.clone()) {
+            Entry::Occupied(entry) => (Some(*entry.get()), false),
+            Entry::Vacant(entry) => {
+                if self.first_unused_span_idx >= MAP_SIZE {
+                    log::warn!(
+                        "OTel span bitmap overflow: more than {MAP_SIZE} unique span types seen; consider increasing MAP_SIZE"
+                    );
+                    return (None, false);
+                }
+
+                let idx = self.first_unused_span_idx;
+                self.first_unused_span_idx += 1;
+                self.span_names.push(key);
+                entry.insert(idx);
+                (Some(idx), true)
+            }
+        }
+    }
+
+    fn get_or_assign_edge_idx(&mut self, key: EdgeKey) -> (Option<usize>, bool) {
+        match self.edge_index.entry(key.clone()) {
+            Entry::Occupied(entry) => (Some(*entry.get()), false),
+            Entry::Vacant(entry) => {
+                if self.first_unused_edge_idx >= MAP_SIZE {
+                    log::warn!(
+                        "OTel edge bitmap overflow: more than {MAP_SIZE} unique span edges seen; consider increasing MAP_SIZE"
+                    );
+                    return (None, false);
+                }
+
+                let idx = self.first_unused_edge_idx;
+                self.first_unused_edge_idx += 1;
+                self.edge_names.push(key);
+                entry.insert(idx);
+                (Some(idx), true)
+            }
+        }
+    }
+
+    pub(crate) fn span_key_count(&self) -> usize {
+        self.span_names.len()
+    }
+
+    pub(crate) fn edge_key_count(&self) -> usize {
+        self.edge_names.len()
+    }
+
+    pub(crate) fn apply_span_key(&mut self, key: SpanKey) -> bool {
+        let (maybe_idx, was_new) = self.get_or_assign_span_idx(key);
+        if let Some(idx) = maybe_idx {
+            self.cov_map[idx] = 1;
+        }
+        was_new
+    }
+
+    pub(crate) fn apply_edge_key(&mut self, key: EdgeKey) -> bool {
+        let (maybe_idx, was_new) = self.get_or_assign_edge_idx(key);
+        if let Some(idx) = maybe_idx {
+            self.cov_map[MAP_SIZE + idx] = 1;
+        }
+        was_new
+    }
+
+    #[cfg(test)]
+    pub(crate) fn apply_spans(&mut self, spans: Vec<ParsedSpan>) -> bool {
+        let mut novel = false;
+        let span_id_map: HashMap<&str, SpanKey> = spans
+            .iter()
+            .map(|span| (span.span_id.as_str(), SpanKey::from_span(span)))
+            .collect();
+
+        for span in &spans {
+            let span_key = SpanKey::from_span(span);
+            novel |= self.apply_span_key(span_key.clone());
+
+            if span.parent_span_id.is_empty() {
+                continue;
+            }
+
+            if let Some(parent_key) = span_id_map.get(span.parent_span_id.as_str()) {
+                novel |= self.apply_edge_key(EdgeKey::new(parent_key.clone(), span_key));
+            }
+        }
+
+        novel
+    }
+
+    pub(crate) fn coverage_ratio(&self) -> (u64, u64) {
+        ((self.span_index.len() + self.edge_index.len()) as u64, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(service: &str, name: &str, span_id: &str, parent_span_id: &str) -> ParsedSpan {
+        ParsedSpan {
+            service_namespace: None,
+            service: service.to_owned(),
+            name: name.to_owned(),
+            kind: OtelSpanKind::Internal,
+            http_request_method: None,
+            http_route: None,
+            url_template: None,
+            rpc_system_name: None,
+            rpc_method: None,
+            trace_id: "trace".to_owned(),
+            span_id: span_id.to_owned(),
+            parent_span_id: parent_span_id.to_owned(),
+            start_time_unix_nano: 0,
+            end_time_unix_nano: 1,
+        }
+    }
+
+    #[test]
+    fn apply_spans_sets_span_byte_to_one() {
+        let mut state = OtelCoverageState::default();
+        state.apply_spans(vec![span("webgoat", "GET /login", "s1", "")]);
+
+        let idx = state.span_index[&span_key("webgoat", OtelSpanKind::Internal, "GET /login")];
+        assert_eq!(state.cov_map[idx], 1);
+    }
+
+    #[test]
+    fn apply_spans_different_operations_get_different_byte_indices() {
+        let mut state = OtelCoverageState::default();
+        state.apply_spans(vec![
+            span("webgoat", "GET /login", "s1", ""),
+            span("webgoat", "POST /api/user", "s2", ""),
+        ]);
+
+        let idx_a = state.span_index[&span_key("webgoat", OtelSpanKind::Internal, "GET /login")];
+        let idx_b =
+            state.span_index[&span_key("webgoat", OtelSpanKind::Internal, "POST /api/user")];
+        assert_ne!(idx_a, idx_b);
+    }
+
+    #[test]
+    fn apply_spans_sets_edge_byte_for_known_parent() {
+        let mut state = OtelCoverageState::default();
+        state.apply_spans(vec![
+            span("webgoat", "root-op", "s1", ""),
+            span("webgoat", "child-op", "s2", "s1"),
+        ]);
+
+        let edge_idx = state.edge_index[&EdgeKey::new(
+            span_key("webgoat", OtelSpanKind::Internal, "root-op"),
+            span_key("webgoat", OtelSpanKind::Internal, "child-op"),
+        )];
+        assert_eq!(state.cov_map[MAP_SIZE + edge_idx], 1);
+    }
+
+    #[test]
+    fn server_http_route_defines_operation_instead_of_raw_span_name() {
+        let mut state = OtelCoverageState::default();
+        let mut first = span("svc", "GET /users/123", "s1", "");
+        first.kind = OtelSpanKind::Server;
+        first.http_request_method = Some("GET".to_owned());
+        first.http_route = Some("/users/{id}".to_owned());
+
+        let mut second = span("svc", "GET /users/456", "s2", "");
+        second.kind = OtelSpanKind::Server;
+        second.http_request_method = Some("GET".to_owned());
+        second.http_route = Some("/users/{id}".to_owned());
+
+        assert!(state.apply_spans(vec![first]));
+        assert!(!state.apply_spans(vec![second]));
+        assert!(state.span_index.contains_key(&span_key(
+            "svc",
+            OtelSpanKind::Server,
+            "HTTP GET /users/{id}"
+        )));
+    }
+
+    #[test]
+    fn span_kind_distinguishes_same_operation_name() {
+        let mut state = OtelCoverageState::default();
+        let mut server = span("svc", "GET /users", "s1", "");
+        server.kind = OtelSpanKind::Server;
+        let mut client = span("svc", "GET /users", "s2", "");
+        client.kind = OtelSpanKind::Client;
+
+        assert!(state.apply_spans(vec![server]));
+        assert!(state.apply_spans(vec![client]));
+        assert_eq!(state.coverage_ratio(), (2, 0));
+    }
+
+    #[test]
+    fn apply_spans_returns_true_only_for_new_coverage() {
+        let mut state = OtelCoverageState::default();
+        assert!(state.apply_spans(vec![span("svc", "op", "s1", "")]));
+        assert!(!state.apply_spans(vec![span("svc", "op", "s2", "")]));
+    }
+
+    #[test]
+    fn max_coverage_ratio_counts_spans_and_edges() {
+        let mut state = OtelCoverageState::default();
+        state.apply_spans(vec![
+            span("svc", "op-a", "s1", ""),
+            span("svc", "op-b", "s2", "s1"),
+        ]);
+        let (covered, total) = state.coverage_ratio();
+        assert_eq!(covered, 3);
+        assert_eq!(total, 0);
+    }
+
+    fn span_key(service: &str, kind: OtelSpanKind, operation: &str) -> SpanKey {
+        SpanKey {
+            service_namespace: None,
+            service: service.to_owned(),
+            kind,
+            operation: operation.to_owned(),
+        }
+    }
+}

--- a/src/coverage_clients/otel/mod.rs
+++ b/src/coverage_clients/otel/mod.rs
@@ -1,4 +1,6 @@
 //! OpenTelemetry coverage client and built-in OTLP receivers.
+//!
+//! See OPENTELEMETRY.md in the repository root for high-level design and usage information.
 
 mod arbiter;
 mod client;

--- a/src/coverage_clients/otel/mod.rs
+++ b/src/coverage_clients/otel/mod.rs
@@ -1,0 +1,16 @@
+//! OpenTelemetry coverage client and built-in OTLP receivers.
+
+mod arbiter;
+mod client;
+mod coverage;
+mod otlp_grpc;
+mod otlp_http;
+mod receiver;
+mod trace_store;
+mod types;
+
+pub use client::OtelCoverageClient;
+pub use types::{
+    SharedOtelTraceProcessingMetrics, new_otel_trace_processing_metrics,
+    read_otel_trace_processing_metrics,
+};

--- a/src/coverage_clients/otel/otlp_grpc.rs
+++ b/src/coverage_clients/otel/otlp_grpc.rs
@@ -1,3 +1,6 @@
+//! OTLP/gRPC `TraceService` implementation: accepts `Export` calls and forwards the parsed
+//! spans to the arbiter job queue.
+
 use opentelemetry_proto::tonic::collector::trace::v1::{
     ExportTraceServiceRequest, ExportTraceServiceResponse,
     trace_service_server::{TraceService, TraceServiceServer},

--- a/src/coverage_clients/otel/otlp_grpc.rs
+++ b/src/coverage_clients/otel/otlp_grpc.rs
@@ -1,0 +1,121 @@
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+    trace_service_server::{TraceService, TraceServiceServer},
+};
+use tokio::sync::mpsc::{Sender, error::TrySendError};
+use tonic::{Request, Response, Status, codec::CompressionEncoding};
+
+use super::{
+    otlp_http::parse_export_trace_service_request,
+    types::{
+        ArbiterMessage, SharedOtelTraceProcessingMetrics, record_engine_backpressure,
+        record_engine_queue_depth,
+    },
+};
+
+#[derive(Clone)]
+pub(crate) struct OtlpGrpcService {
+    span_tx: Sender<ArbiterMessage>,
+    metrics: SharedOtelTraceProcessingMetrics,
+}
+
+impl OtlpGrpcService {
+    pub(crate) fn new(
+        span_tx: Sender<ArbiterMessage>,
+        metrics: SharedOtelTraceProcessingMetrics,
+    ) -> Self {
+        Self { span_tx, metrics }
+    }
+
+    pub(crate) fn into_server(self) -> TraceServiceServer<Self> {
+        TraceServiceServer::new(self).accept_compressed(CompressionEncoding::Gzip)
+    }
+}
+
+fn update_ok_metrics(metrics: &SharedOtelTraceProcessingMetrics, spans: usize) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    metrics.receiver_requests_ok = metrics.receiver_requests_ok.saturating_add(1);
+    metrics.spans_received = metrics.spans_received.saturating_add(spans as u64);
+}
+
+fn update_queue_depth(
+    span_tx: &Sender<ArbiterMessage>,
+    metrics: &SharedOtelTraceProcessingMetrics,
+) {
+    record_engine_queue_depth(metrics, span_tx.max_capacity() - span_tx.capacity());
+}
+
+fn update_rejected_metric(metrics: &SharedOtelTraceProcessingMetrics) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    metrics.receiver_requests_rejected = metrics.receiver_requests_rejected.saturating_add(1);
+}
+
+#[tonic::async_trait]
+impl TraceService for OtlpGrpcService {
+    async fn export(
+        &self,
+        request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        let spans = parse_export_trace_service_request(request.into_inner());
+        let span_count = spans.len();
+        match self.span_tx.try_send(ArbiterMessage::ReceivedSpans(spans)) {
+            Ok(()) => {
+                update_queue_depth(&self.span_tx, &self.metrics);
+                update_ok_metrics(&self.metrics, span_count);
+                Ok(Response::new(ExportTraceServiceResponse {
+                    partial_success: None,
+                }))
+            }
+            Err(TrySendError::Full(_)) => {
+                log::warn!("OTel arbiter queue is saturated; rejecting OTLP/gRPC export for retry");
+                record_engine_backpressure(&self.metrics);
+                update_queue_depth(&self.span_tx, &self.metrics);
+                update_rejected_metric(&self.metrics);
+                Err(Status::unavailable(
+                    "OTel arbiter is overloaded; retry export later",
+                ))
+            }
+            Err(TrySendError::Closed(_)) => {
+                log::warn!(
+                    "OTLP/gRPC receiver could not hand spans to the arbiter; delayed OTel guidance is unavailable"
+                );
+                update_rejected_metric(&self.metrics);
+                Err(Status::unavailable(
+                    "OTel arbiter is temporarily unavailable; retry export later",
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+    use tonic::Request;
+
+    use super::*;
+    use crate::coverage_clients::otel::types::new_otel_trace_processing_metrics;
+
+    #[tokio::test]
+    async fn grpc_export_accepts_empty_request() {
+        let (span_tx, mut span_rx) = tokio::sync::mpsc::channel(1);
+        let metrics = new_otel_trace_processing_metrics();
+        let service = OtlpGrpcService::new(span_tx, metrics.clone());
+
+        service
+            .export(Request::new(ExportTraceServiceRequest {
+                resource_spans: Vec::new(),
+            }))
+            .await
+            .expect("empty export should be accepted");
+
+        assert!(
+            matches!(span_rx.try_recv(), Ok(ArbiterMessage::ReceivedSpans(spans)) if spans.is_empty())
+        );
+        assert_eq!(metrics.lock().unwrap().receiver_requests_ok, 1);
+    }
+}

--- a/src/coverage_clients/otel/otlp_http.rs
+++ b/src/coverage_clients/otel/otlp_http.rs
@@ -20,8 +20,10 @@ use prost::Message;
 use prost_types::Any;
 use tokio::sync::mpsc::{Sender, error::TrySendError};
 
-use super::types::{ArbiterMessage, OtelSpanKind, ParsedSpan, SharedOtelTraceProcessingMetrics};
-use super::types::{record_engine_backpressure, record_engine_queue_depth};
+use super::types::{
+    ArbiterMessage, OtelSpanKind, ParsedSpan, SharedOtelTraceProcessingMetrics,
+    record_engine_backpressure, record_engine_queue_depth,
+};
 
 #[derive(Clone)]
 pub(crate) struct OtlpHttpState {

--- a/src/coverage_clients/otel/otlp_http.rs
+++ b/src/coverage_clients/otel/otlp_http.rs
@@ -1,0 +1,518 @@
+use std::io::Read;
+
+use axum::{
+    Router,
+    body::{Body, Bytes},
+    extract::State,
+    http::{HeaderMap, Method, StatusCode, Uri, header},
+    response::Response,
+    routing::post,
+};
+use flate2::read::GzDecoder;
+use opentelemetry_proto::tonic::{
+    collector::trace::v1::{ExportTraceServiceRequest, ExportTraceServiceResponse},
+    common::v1::{KeyValue, any_value::Value},
+};
+use prost::Message;
+use prost_types::Any;
+use tokio::sync::mpsc::{Sender, error::TrySendError};
+
+use super::types::{ArbiterMessage, OtelSpanKind, ParsedSpan, SharedOtelTraceProcessingMetrics};
+use super::types::{record_engine_backpressure, record_engine_queue_depth};
+
+#[derive(Clone)]
+pub(crate) struct OtlpHttpState {
+    span_tx: Sender<ArbiterMessage>,
+    metrics: SharedOtelTraceProcessingMetrics,
+}
+
+impl OtlpHttpState {
+    pub(crate) fn new(
+        span_tx: Sender<ArbiterMessage>,
+        metrics: SharedOtelTraceProcessingMetrics,
+    ) -> Self {
+        Self { span_tx, metrics }
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct RpcStatus {
+    #[prost(int32, tag = "1")]
+    code: i32,
+    #[prost(string, tag = "2")]
+    message: String,
+    #[prost(message, repeated, tag = "3")]
+    details: Vec<Any>,
+}
+
+fn update_ok_metrics(metrics: &SharedOtelTraceProcessingMetrics, spans: usize) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    metrics.receiver_requests_ok = metrics.receiver_requests_ok.saturating_add(1);
+    metrics.spans_received = metrics.spans_received.saturating_add(spans as u64);
+}
+
+fn update_queue_depth(
+    span_tx: &Sender<ArbiterMessage>,
+    metrics: &SharedOtelTraceProcessingMetrics,
+) {
+    record_engine_queue_depth(metrics, span_tx.max_capacity() - span_tx.capacity());
+}
+
+fn update_rejected_metric(metrics: &SharedOtelTraceProcessingMetrics) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    metrics.receiver_requests_rejected = metrics.receiver_requests_rejected.saturating_add(1);
+}
+
+fn update_decode_error_metric(metrics: &SharedOtelTraceProcessingMetrics) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    metrics.receiver_requests_decode_error =
+        metrics.receiver_requests_decode_error.saturating_add(1);
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn string_attribute(attributes: &[KeyValue], key: &str) -> Option<String> {
+    attributes
+        .iter()
+        .find(|attribute| attribute.key == key)
+        .and_then(|attribute| attribute.value.as_ref())
+        .and_then(|value| value.value.as_ref())
+        .and_then(|value| match value {
+            Value::StringValue(value) => Some(value.clone()),
+            _ => None,
+        })
+}
+
+pub(crate) fn parse_export_trace_service_request(
+    request: ExportTraceServiceRequest,
+) -> Vec<ParsedSpan> {
+    let mut parsed = Vec::new();
+
+    for resource_spans in request.resource_spans {
+        let (service_namespace, service) = resource_spans
+            .resource
+            .as_ref()
+            .map(|resource| {
+                (
+                    string_attribute(&resource.attributes, "service.namespace")
+                        .filter(|namespace| !namespace.is_empty()),
+                    string_attribute(&resource.attributes, "service.name")
+                        .filter(|service| !service.is_empty())
+                        .unwrap_or_else(|| "unknown_service".to_owned()),
+                )
+            })
+            .unwrap_or_else(|| (None, "unknown_service".to_owned()));
+
+        for scope_spans in resource_spans.scope_spans {
+            for span in scope_spans.spans {
+                if span.trace_id.len() != 16 {
+                    log::warn!(
+                        "Received OTLP span '{}' with invalid trace ID length {}; skipping span",
+                        span.name,
+                        span.trace_id.len()
+                    );
+                    continue;
+                }
+
+                if span.span_id.len() != 8 {
+                    log::warn!(
+                        "Received OTLP span '{}' with invalid span ID length {}; skipping span",
+                        span.name,
+                        span.span_id.len()
+                    );
+                    continue;
+                }
+
+                if !span.parent_span_id.is_empty() && span.parent_span_id.len() != 8 {
+                    log::warn!(
+                        "Received OTLP span '{}' with invalid parent span ID length {}; skipping span",
+                        span.name,
+                        span.parent_span_id.len()
+                    );
+                    continue;
+                }
+
+                parsed.push(ParsedSpan {
+                    service_namespace: service_namespace.clone(),
+                    service: service.clone(),
+                    name: span.name,
+                    kind: OtelSpanKind::from_otlp_kind(span.kind),
+                    http_request_method: string_attribute(&span.attributes, "http.request.method")
+                        .or_else(|| string_attribute(&span.attributes, "http.method")),
+                    http_route: string_attribute(&span.attributes, "http.route"),
+                    url_template: string_attribute(&span.attributes, "url.template"),
+                    rpc_system_name: string_attribute(&span.attributes, "rpc.system.name")
+                        .or_else(|| string_attribute(&span.attributes, "rpc.system")),
+                    rpc_method: string_attribute(&span.attributes, "rpc.method"),
+                    trace_id: lower_hex(&span.trace_id),
+                    span_id: lower_hex(&span.span_id),
+                    parent_span_id: lower_hex(&span.parent_span_id),
+                    start_time_unix_nano: span.start_time_unix_nano,
+                    end_time_unix_nano: span.end_time_unix_nano,
+                });
+            }
+        }
+    }
+
+    parsed
+}
+
+fn protobuf_response<T: Message>(
+    status_code: StatusCode,
+    body: T,
+    retry_after: Option<u64>,
+) -> Response {
+    let mut builder = Response::builder()
+        .status(status_code)
+        .header(header::CONTENT_TYPE, "application/x-protobuf");
+
+    if let Some(seconds) = retry_after {
+        builder = builder.header(header::RETRY_AFTER, seconds.to_string());
+    }
+
+    builder
+        .body(Body::from(body.encode_to_vec()))
+        .expect("hardcoded OTLP response headers should be valid")
+}
+
+fn success_response() -> Response {
+    protobuf_response(
+        StatusCode::OK,
+        ExportTraceServiceResponse {
+            partial_success: None,
+        },
+        None,
+    )
+}
+
+fn error_response(status_code: StatusCode, message: impl Into<String>) -> Response {
+    protobuf_response(
+        status_code,
+        RpcStatus {
+            code: 0,
+            message: message.into(),
+            details: Vec::new(),
+        },
+        None,
+    )
+}
+
+fn service_unavailable_response(message: impl Into<String>) -> Response {
+    protobuf_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        RpcStatus {
+            code: 0,
+            message: message.into(),
+            details: Vec::new(),
+        },
+        Some(1),
+    )
+}
+
+fn header_value(headers: &HeaderMap, header_name: header::HeaderName) -> Option<String> {
+    headers
+        .get(header_name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
+}
+
+fn is_binary_protobuf_content_type(headers: &HeaderMap) -> bool {
+    header_value(headers, header::CONTENT_TYPE)
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .map(str::trim)
+                .is_some_and(|content_type| {
+                    content_type.eq_ignore_ascii_case("application/x-protobuf")
+                })
+        })
+        .unwrap_or(false)
+}
+
+fn decode_body(headers: &HeaderMap, body: Bytes) -> Result<Vec<u8>, String> {
+    match header_value(headers, header::CONTENT_ENCODING).as_deref() {
+        None | Some("") => Ok(body.to_vec()),
+        Some(content_encoding) if content_encoding.eq_ignore_ascii_case("identity") => {
+            Ok(body.to_vec())
+        }
+        Some(content_encoding) if content_encoding.eq_ignore_ascii_case("gzip") => {
+            let mut decoded = Vec::new();
+            let mut decoder = GzDecoder::new(body.as_ref());
+            decoder
+                .read_to_end(&mut decoded)
+                .map_err(|error| format!("failed to decompress gzip OTLP request body: {error}"))?;
+            Ok(decoded)
+        }
+        Some(content_encoding) => Err(format!(
+            "unsupported Content-Encoding '{content_encoding}'; only identity and gzip are supported"
+        )),
+    }
+}
+
+pub(crate) fn build_otlp_http_router(state: OtlpHttpState) -> Router {
+    Router::new()
+        .route("/v1/traces", post(handle_otlp_http_request))
+        .fallback(handle_otlp_http_fallback)
+        .with_state(state)
+}
+
+async fn handle_otlp_http_fallback(
+    State(state): State<OtlpHttpState>,
+    method: Method,
+    uri: Uri,
+) -> Response {
+    log::warn!(
+        "OTLP receiver rejected {} {}: only POST /v1/traces is supported",
+        method,
+        uri
+    );
+    update_rejected_metric(&state.metrics);
+
+    if uri.path() == "/v1/traces" {
+        error_response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "only POST /v1/traces is supported for OTLP trace export",
+        )
+    } else {
+        error_response(
+            StatusCode::NOT_FOUND,
+            "only /v1/traces is supported for OTLP trace export",
+        )
+    }
+}
+
+pub(crate) async fn handle_otlp_http_request(
+    State(state): State<OtlpHttpState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if !is_binary_protobuf_content_type(&headers) {
+        log::warn!(
+            "OTLP receiver rejected request with unsupported Content-Type {:?}; only application/x-protobuf is currently supported",
+            header_value(&headers, header::CONTENT_TYPE)
+        );
+        update_rejected_metric(&state.metrics);
+        return error_response(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "only application/x-protobuf OTLP/HTTP requests are supported",
+        );
+    }
+
+    let body = match decode_body(&headers, body) {
+        Ok(body) => body,
+        Err(error) => {
+            log::warn!("{error}");
+            if error.contains("unsupported Content-Encoding") {
+                update_rejected_metric(&state.metrics);
+                return error_response(StatusCode::UNSUPPORTED_MEDIA_TYPE, error);
+            }
+
+            update_decode_error_metric(&state.metrics);
+            return error_response(StatusCode::BAD_REQUEST, error);
+        }
+    };
+
+    if body.is_empty() {
+        update_ok_metrics(&state.metrics, 0);
+        return success_response();
+    }
+
+    let export = match ExportTraceServiceRequest::decode(body.as_slice()) {
+        Ok(export) => export,
+        Err(error) => {
+            log::warn!(
+                "Failed to decode OTLP protobuf request body as ExportTraceServiceRequest: {error}"
+            );
+            update_decode_error_metric(&state.metrics);
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                format!("invalid ExportTraceServiceRequest protobuf: {error}"),
+            );
+        }
+    };
+
+    let spans = parse_export_trace_service_request(export);
+    let span_count = spans.len();
+    match state.span_tx.try_send(ArbiterMessage::ReceivedSpans(spans)) {
+        Ok(()) => {
+            update_queue_depth(&state.span_tx, &state.metrics);
+            update_ok_metrics(&state.metrics, span_count);
+            success_response()
+        }
+        Err(TrySendError::Full(_)) => {
+            log::warn!("OTel arbiter queue is saturated; rejecting OTLP/HTTP export for retry");
+            record_engine_backpressure(&state.metrics);
+            update_queue_depth(&state.span_tx, &state.metrics);
+            update_rejected_metric(&state.metrics);
+            service_unavailable_response("OTel arbiter is overloaded; retry export later")
+        }
+        Err(TrySendError::Closed(_)) => {
+            log::warn!(
+                "OTLP receiver could not hand spans to the arbiter; delayed OTel guidance is unavailable"
+            );
+            update_rejected_metric(&state.metrics);
+            service_unavailable_response(
+                "OTel arbiter is temporarily unavailable; retry export later",
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Bytes,
+        extract::State,
+        http::{HeaderMap, HeaderValue, StatusCode, header},
+    };
+    use opentelemetry_proto::tonic::{
+        collector::trace::v1::ExportTraceServiceRequest,
+        common::v1::{AnyValue, KeyValue, any_value::Value},
+        resource::v1::Resource,
+        trace::v1::{ResourceSpans, ScopeSpans, Span},
+    };
+    use prost::Message;
+
+    use super::{OtlpHttpState, handle_otlp_http_request, parse_export_trace_service_request};
+    use crate::coverage_clients::otel::types::{
+        ArbiterMessage, OtelSpanKind, new_otel_trace_processing_metrics,
+    };
+
+    fn string_attribute(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_owned(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(value.to_owned())),
+            }),
+            key_strindex: 0,
+        }
+    }
+
+    fn protobuf_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-protobuf"),
+        );
+        headers
+    }
+
+    #[test]
+    fn parse_export_request_extracts_service_name_and_span_fields() {
+        let export = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![
+                        string_attribute("service.namespace", "owasp"),
+                        string_attribute("service.name", "webgoat"),
+                    ],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![
+                            0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d,
+                            0x0e, 0x0e, 0x47, 0x36,
+                        ],
+                        span_id: vec![0x56, 0xc5, 0x8a, 0x1f, 0x0b, 0x7d, 0x51, 0x10],
+                        trace_state: String::new(),
+                        parent_span_id: vec![0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11],
+                        flags: 0,
+                        name: "GET /WebGoat/login".to_owned(),
+                        kind: 2,
+                        start_time_unix_nano: 10,
+                        end_time_unix_nano: 20,
+                        attributes: vec![
+                            string_attribute("http.request.method", "GET"),
+                            string_attribute("http.route", "/WebGoat/login"),
+                        ],
+                        dropped_attributes_count: 0,
+                        events: Vec::new(),
+                        dropped_events_count: 0,
+                        links: Vec::new(),
+                        dropped_links_count: 0,
+                        status: None,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let parsed = parse_export_trace_service_request(export);
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].service_namespace.as_deref(), Some("owasp"));
+        assert_eq!(parsed[0].service, "webgoat");
+        assert_eq!(parsed[0].name, "GET /WebGoat/login");
+        assert_eq!(parsed[0].kind, OtelSpanKind::Server);
+        assert_eq!(parsed[0].http_request_method.as_deref(), Some("GET"));
+        assert_eq!(parsed[0].http_route.as_deref(), Some("/WebGoat/login"));
+        assert_eq!(parsed[0].trace_id, "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(parsed[0].span_id, "56c58a1f0b7d5110");
+        assert_eq!(parsed[0].parent_span_id, "aabbccddeeff0011");
+        assert_eq!(parsed[0].start_time_unix_nano, 10);
+        assert_eq!(parsed[0].end_time_unix_nano, 20);
+    }
+
+    #[tokio::test]
+    async fn http_export_accepts_empty_body() {
+        let (span_tx, mut span_rx) = tokio::sync::mpsc::channel(1);
+        let metrics = new_otel_trace_processing_metrics();
+
+        let response = handle_otlp_http_request(
+            State(OtlpHttpState::new(span_tx, metrics.clone())),
+            protobuf_headers(),
+            Bytes::new(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(span_rx.try_recv().is_err());
+        assert_eq!(metrics.lock().unwrap().receiver_requests_ok, 1);
+    }
+
+    #[tokio::test]
+    async fn http_export_returns_503_when_engine_queue_is_full() {
+        let (span_tx, mut span_rx) = tokio::sync::mpsc::channel(1);
+        span_tx
+            .try_send(ArbiterMessage::Shutdown)
+            .expect("test queue should accept filler message");
+        let metrics = new_otel_trace_processing_metrics();
+        let body = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: None,
+                scope_spans: Vec::new(),
+                schema_url: String::new(),
+            }],
+        }
+        .encode_to_vec();
+
+        let response = handle_otlp_http_request(
+            State(OtlpHttpState::new(span_tx, metrics.clone())),
+            protobuf_headers(),
+            Bytes::from(body),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(matches!(span_rx.try_recv(), Ok(ArbiterMessage::Shutdown)));
+        assert_eq!(metrics.lock().unwrap().receiver_requests_rejected, 1);
+    }
+}

--- a/src/coverage_clients/otel/otlp_http.rs
+++ b/src/coverage_clients/otel/otlp_http.rs
@@ -1,3 +1,6 @@
+//! OTLP/HTTP receiver: an Axum router that accepts `POST /v1/traces` (protobuf or JSON,
+//! optionally gzip-compressed), parses spans, and forwards them to the arbiter job queue.
+
 use std::io::Read;
 
 use axum::{

--- a/src/coverage_clients/otel/receiver.rs
+++ b/src/coverage_clients/otel/receiver.rs
@@ -1,0 +1,258 @@
+use std::{
+    net::{SocketAddr, TcpListener as StdTcpListener},
+    sync::mpsc::Sender as StdSender,
+    thread::{self, JoinHandle},
+};
+
+use anyhow::{Context, anyhow};
+use tokio::{net::TcpListener, runtime, sync::watch};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+
+use super::{
+    arbiter::run_otel_arbiter,
+    coverage::SharedCoverageState,
+    otlp_grpc::OtlpGrpcService,
+    otlp_http::{OtlpHttpState, build_otlp_http_router},
+    types::{ArbiterMessage, DEFAULT_ARBITER_QUEUE_CAPACITY, SharedOtelTraceProcessingMetrics},
+};
+
+pub(crate) struct OtelReceiverHandle {
+    job_tx: tokio::sync::mpsc::Sender<ArbiterMessage>,
+    shutdown_tx: Option<watch::Sender<bool>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl OtelReceiverHandle {
+    pub(crate) fn job_tx(&self) -> tokio::sync::mpsc::Sender<ArbiterMessage> {
+        self.job_tx.clone()
+    }
+}
+
+impl Drop for OtelReceiverHandle {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(true);
+        }
+
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn bind_tcp_listener(bind_addr: SocketAddr, description: &str) -> anyhow::Result<StdTcpListener> {
+    let listener = StdTcpListener::bind(bind_addr)
+        .map_err(|error| anyhow!("failed to bind {description} on {bind_addr}: {error}"))?;
+    listener
+        .set_nonblocking(true)
+        .with_context(|| format!("failed to set {description} listener nonblocking"))?;
+    Ok(listener)
+}
+
+async fn run_http_receiver(
+    listener: StdTcpListener,
+    span_tx: tokio::sync::mpsc::Sender<ArbiterMessage>,
+    metrics: SharedOtelTraceProcessingMetrics,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let listener = match TcpListener::from_std(listener) {
+        Ok(listener) => listener,
+        Err(error) => {
+            log::warn!("Failed to convert OTLP/HTTP listener to Tokio listener: {error}");
+            return;
+        }
+    };
+    let app = build_otlp_http_router(OtlpHttpState::new(span_tx, metrics));
+    let shutdown = async move {
+        let _ = shutdown_rx.changed().await;
+    };
+
+    if let Err(error) = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+    {
+        log::warn!("OTLP/HTTP receiver stopped with error: {error}");
+    }
+}
+
+async fn run_grpc_receiver(
+    listener: StdTcpListener,
+    span_tx: tokio::sync::mpsc::Sender<ArbiterMessage>,
+    metrics: SharedOtelTraceProcessingMetrics,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let listener = match TcpListener::from_std(listener) {
+        Ok(listener) => listener,
+        Err(error) => {
+            log::warn!("Failed to convert OTLP/gRPC listener to Tokio listener: {error}");
+            return;
+        }
+    };
+    let incoming = TcpListenerStream::new(listener);
+    let shutdown = async move {
+        let _ = shutdown_rx.changed().await;
+    };
+
+    if let Err(error) = Server::builder()
+        .add_service(OtlpGrpcService::new(span_tx, metrics).into_server())
+        .serve_with_incoming_shutdown(incoming, shutdown)
+        .await
+    {
+        log::warn!("OTLP/gRPC receiver stopped with error: {error}");
+    }
+}
+
+pub(crate) fn start_otel_receiver(
+    http_bind_addr: Option<SocketAddr>,
+    grpc_bind_addr: Option<SocketAddr>,
+    coverage_state: SharedCoverageState,
+    metrics: SharedOtelTraceProcessingMetrics,
+    promotion_tx: StdSender<super::types::PromotionCandidate>,
+) -> anyhow::Result<OtelReceiverHandle> {
+    if http_bind_addr.is_none() && grpc_bind_addr.is_none() {
+        return Err(anyhow!(
+            "OpenTelemetry coverage requires at least one enabled OTLP receiver"
+        ));
+    }
+
+    let http_listener = http_bind_addr
+        .map(|bind_addr| bind_tcp_listener(bind_addr, "OTLP/HTTP receiver"))
+        .transpose()?;
+    let grpc_listener = grpc_bind_addr
+        .map(|bind_addr| bind_tcp_listener(bind_addr, "OTLP/gRPC receiver"))
+        .transpose()?;
+
+    if let Some(listener) = &http_listener {
+        let http_bound_addr = listener
+            .local_addr()
+            .context("failed to read bound OTLP/HTTP receiver address")?;
+        log::info!(
+            "Started built-in OTLP/HTTP receiver on {http_bound_addr}; point target auto-instrumentation at http://<this-host>:{}/v1/traces",
+            http_bound_addr.port()
+        );
+        if http_bound_addr.ip().is_loopback() {
+            log::warn!(
+                "The OTLP/HTTP receiver is bound to loopback ({http_bound_addr}); containerized fuzzing targets will usually not be able to reach it"
+            );
+        }
+    } else {
+        log::info!("Built-in OTLP/HTTP receiver disabled");
+    }
+
+    if let Some(listener) = &grpc_listener {
+        let grpc_bound_addr = listener
+            .local_addr()
+            .context("failed to read bound OTLP/gRPC receiver address")?;
+        log::info!(
+            "Started built-in OTLP/gRPC receiver on {grpc_bound_addr}; point target auto-instrumentation at grpc://<this-host>:{}",
+            grpc_bound_addr.port()
+        );
+        if grpc_bound_addr.ip().is_loopback() {
+            log::warn!(
+                "The OTLP/gRPC receiver is bound to loopback ({grpc_bound_addr}); containerized fuzzing targets will usually not be able to reach it"
+            );
+        }
+    } else {
+        log::info!("Built-in OTLP/gRPC receiver disabled");
+    }
+
+    let (job_tx, job_rx) = tokio::sync::mpsc::channel(DEFAULT_ARBITER_QUEUE_CAPACITY);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let http_span_tx = job_tx.clone();
+    let http_metrics = metrics.clone();
+    let http_shutdown_rx = shutdown_rx.clone();
+    let grpc_span_tx = job_tx.clone();
+    let grpc_metrics = metrics.clone();
+    let grpc_shutdown_rx = shutdown_rx.clone();
+    let arbiter_shutdown_rx = shutdown_rx.clone();
+
+    let thread = thread::Builder::new()
+        .name("otel-runtime".to_owned())
+        .spawn(move || {
+            let runtime = match runtime::Builder::new_current_thread().enable_all().build() {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    log::error!("Failed to start OTEL Tokio runtime: {error}");
+                    return;
+                }
+            };
+
+            runtime.block_on(async move {
+                let http_task = http_listener.map(|listener| {
+                    tokio::spawn(run_http_receiver(
+                        listener,
+                        http_span_tx,
+                        http_metrics,
+                        http_shutdown_rx,
+                    ))
+                });
+
+                let grpc_task = grpc_listener.map(|listener| {
+                    tokio::spawn(run_grpc_receiver(
+                        listener,
+                        grpc_span_tx,
+                        grpc_metrics,
+                        grpc_shutdown_rx,
+                    ))
+                });
+
+                let arbiter_task = tokio::spawn(run_otel_arbiter(
+                    coverage_state,
+                    metrics,
+                    job_rx,
+                    promotion_tx,
+                    arbiter_shutdown_rx,
+                ));
+
+                let _ = arbiter_task.await;
+                if let Some(http_task) = http_task {
+                    let _ = http_task.await;
+                }
+                if let Some(grpc_task) = grpc_task {
+                    let _ = grpc_task.await;
+                }
+            });
+        })
+        .context("failed to spawn OTEL runtime thread")?;
+
+    Ok(OtelReceiverHandle {
+        job_tx,
+        shutdown_tx: Some(shutdown_tx),
+        thread: Some(thread),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receiver_requires_at_least_one_enabled_protocol() {
+        let coverage_state = super::super::coverage::new_shared_coverage_state();
+        let metrics = super::super::types::new_otel_trace_processing_metrics();
+        let (promotion_tx, _promotion_rx) = std::sync::mpsc::channel();
+
+        let result = start_otel_receiver(None, None, coverage_state, metrics, promotion_tx);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn receiver_allows_http_only() {
+        let coverage_state = super::super::coverage::new_shared_coverage_state();
+        let metrics = super::super::types::new_otel_trace_processing_metrics();
+        let (promotion_tx, _promotion_rx) = std::sync::mpsc::channel();
+
+        let result = start_otel_receiver(
+            Some("127.0.0.1:0".parse().unwrap()),
+            None,
+            coverage_state,
+            metrics,
+            promotion_tx,
+        );
+
+        assert!(result.is_ok());
+    }
+}

--- a/src/coverage_clients/otel/receiver.rs
+++ b/src/coverage_clients/otel/receiver.rs
@@ -1,3 +1,6 @@
+//! Spawns the background Tokio runtime that runs the OTLP/HTTP and OTLP/gRPC receivers
+//! alongside the arbiter task, and exposes a handle to submit jobs and trigger shutdown.
+
 use std::{
     net::{SocketAddr, TcpListener as StdTcpListener},
     sync::mpsc::Sender as StdSender,

--- a/src/coverage_clients/otel/trace_store.rs
+++ b/src/coverage_clients/otel/trace_store.rs
@@ -1,0 +1,921 @@
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
+
+use crate::input::OpenApiInput;
+
+use super::{
+    coverage::{EdgeKey, OtelCoverageState, SpanKey},
+    types::{ParsedSpan, PromotionCandidate},
+};
+
+const MAX_BUFFERED_ORPHAN_TRACES: usize = 10_000;
+const MAX_BUFFERED_ORPHAN_SPANS: usize = 50_000;
+
+#[derive(Debug)]
+struct SequenceState {
+    trace_id: String,
+    expected_parent_ids: HashSet<String>,
+    seen_parent_ids: HashSet<String>,
+    observed_parent_ids: HashSet<String>,
+    spans_by_id: HashMap<String, SpanKey>,
+    pending_children_by_parent_id: HashMap<String, Vec<SpanKey>>,
+    started_at: Instant,
+    finished_at: Option<Instant>,
+    last_update: Instant,
+    last_span_at: Option<Instant>,
+    input: OpenApiInput,
+    submission_id: u64,
+    spans_seen: usize,
+    novelty_seen: bool,
+    promotion_emitted: bool,
+}
+
+impl SequenceState {
+    fn new(trace_id: String, submission_id: u64, input: OpenApiInput, started_at: Instant) -> Self {
+        Self {
+            trace_id,
+            expected_parent_ids: HashSet::new(),
+            seen_parent_ids: HashSet::new(),
+            observed_parent_ids: HashSet::new(),
+            spans_by_id: HashMap::new(),
+            pending_children_by_parent_id: HashMap::new(),
+            started_at,
+            finished_at: None,
+            last_update: started_at,
+            last_span_at: None,
+            input,
+            submission_id,
+            spans_seen: 0,
+            novelty_seen: false,
+            promotion_emitted: false,
+        }
+    }
+
+    fn register_parent_id(&mut self, parent_id: String, now: Instant) -> RootRegistrationResult {
+        self.last_update = now;
+        if !self.expected_parent_ids.insert(parent_id.clone()) {
+            return RootRegistrationResult::Duplicate;
+        }
+
+        if self.observed_parent_ids.contains(&parent_id) && self.seen_parent_ids.insert(parent_id) {
+            RootRegistrationResult::RegisteredAfterSpan
+        } else {
+            RootRegistrationResult::Registered
+        }
+    }
+
+    fn finish(&mut self, now: Instant) {
+        self.finished_at = Some(now);
+        self.last_update = now;
+    }
+
+    fn process_span(
+        &mut self,
+        span: ParsedSpan,
+        coverage_state: &mut OtelCoverageState,
+        now: Instant,
+    ) -> SpanProcessResult {
+        self.last_update = now;
+        self.last_span_at = Some(now);
+        self.spans_seen += 1;
+
+        if !span.parent_span_id.is_empty() {
+            self.observed_parent_ids.insert(span.parent_span_id.clone());
+        }
+
+        let newly_seen_root = self.expected_parent_ids.contains(&span.parent_span_id)
+            && self.seen_parent_ids.insert(span.parent_span_id.clone());
+
+        if self.spans_by_id.contains_key(&span.span_id) {
+            return SpanProcessResult { newly_seen_root };
+        }
+
+        let span_key = SpanKey::from_span(&span);
+        let mut novelty_events = 0;
+        if coverage_state.apply_span_key(span_key.clone()) {
+            novelty_events += 1;
+        }
+
+        if !span.parent_span_id.is_empty() {
+            if let Some(parent_key) = self.spans_by_id.get(&span.parent_span_id) {
+                if coverage_state.apply_edge_key(EdgeKey::new(parent_key.clone(), span_key.clone()))
+                {
+                    novelty_events += 1;
+                }
+            } else {
+                self.pending_children_by_parent_id
+                    .entry(span.parent_span_id.clone())
+                    .or_default()
+                    .push(span_key.clone());
+            }
+        }
+
+        self.spans_by_id
+            .insert(span.span_id.clone(), span_key.clone());
+
+        if let Some(children) = self.pending_children_by_parent_id.remove(&span.span_id) {
+            for child_key in children {
+                if coverage_state.apply_edge_key(EdgeKey::new(span_key.clone(), child_key)) {
+                    novelty_events += 1;
+                }
+            }
+        }
+
+        if novelty_events > 0 {
+            self.novelty_seen = true;
+        }
+
+        SpanProcessResult { newly_seen_root }
+    }
+
+    fn maybe_promotion(&mut self, _now: Instant) -> Option<PromotionCandidate> {
+        if !self.novelty_seen || self.promotion_emitted {
+            return None;
+        }
+
+        self.promotion_emitted = true;
+        Some(PromotionCandidate {
+            submission_id: self.submission_id,
+            input: self.input.clone(),
+        })
+    }
+
+    fn expected_parent_count(&self) -> usize {
+        self.expected_parent_ids.len()
+    }
+
+    fn seen_parent_count(&self) -> usize {
+        self.seen_parent_ids.len()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootRegistrationResult {
+    Registered,
+    RegisteredAfterSpan,
+    Duplicate,
+}
+
+#[derive(Default)]
+struct SpanProcessResult {
+    newly_seen_root: bool,
+}
+
+pub(crate) enum TraceStoreEvent {
+    SequenceStarted,
+    DuplicateSequenceStart,
+    RequestRootRegistered,
+    RequestRootRegisteredAfterSpan,
+    RequestRootUnknownTrace,
+    SequenceFinished,
+    SequenceFinishUnknownTrace,
+    OrphanSpan,
+    OrphanSpanBuffered,
+    OrphanSpanReassociated,
+    OrphanSpanExpired,
+    OrphanSpanCapacityDropped,
+    LateAfterEviction,
+    RootSeen,
+    Evicted {
+        trace_id: String,
+        expected_parent_ids: usize,
+        seen_parent_ids: usize,
+        lifetime: Duration,
+        was_novel: bool,
+        reason: EvictionReason,
+    },
+    Promotion {
+        trace_id: String,
+        candidate: PromotionCandidate,
+    },
+    NonNovel {
+        trace_id: String,
+        expected_parent_ids: usize,
+        seen_parent_ids: usize,
+    },
+    Dropped {
+        trace_id: String,
+        expected_parent_ids: usize,
+        seen_parent_ids: usize,
+        waited: Duration,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EvictionReason {
+    Age,
+    Capacity,
+}
+
+struct OrphanTrace {
+    spans: Vec<ParsedSpan>,
+    first_seen: Instant,
+    last_update: Instant,
+}
+
+#[derive(Default)]
+pub(crate) struct TraceStore {
+    sequences: HashMap<String, SequenceState>,
+    seen_trace_ids: HashSet<String>,
+    evicted_trace_ids: HashMap<String, EvictionReason>,
+    orphan_traces: HashMap<String, OrphanTrace>,
+    buffered_orphan_spans: usize,
+}
+
+impl TraceStore {
+    pub(crate) fn start_sequence(
+        &mut self,
+        trace_id: String,
+        submission_id: u64,
+        input: OpenApiInput,
+        coverage_state: &mut OtelCoverageState,
+    ) -> Vec<TraceStoreEvent> {
+        let now = Instant::now();
+        self.seen_trace_ids.insert(trace_id.clone());
+
+        let mut events = Vec::new();
+        if let Some(replaced) = self.sequences.remove(&trace_id) {
+            log::warn!("Replacing active OTel sequence state for duplicate trace {trace_id}");
+            events.push(TraceStoreEvent::DuplicateSequenceStart);
+            events.extend(self.evict_state(replaced, now, EvictionReason::Capacity));
+        }
+
+        let mut state = SequenceState::new(trace_id.clone(), submission_id, input, now);
+        events.push(TraceStoreEvent::SequenceStarted);
+
+        if let Some(orphan_trace) = self.orphan_traces.remove(&trace_id) {
+            self.buffered_orphan_spans = self
+                .buffered_orphan_spans
+                .saturating_sub(orphan_trace.spans.len());
+            for span in orphan_trace.spans {
+                events.push(TraceStoreEvent::OrphanSpanReassociated);
+                let result = state.process_span(span, coverage_state, now);
+                Self::push_span_events(&mut events, result);
+                if let Some(candidate) = state.maybe_promotion(now) {
+                    events.push(TraceStoreEvent::Promotion {
+                        trace_id: trace_id.clone(),
+                        candidate,
+                    });
+                }
+            }
+        }
+
+        self.sequences.insert(trace_id, state);
+        events
+    }
+
+    pub(crate) fn register_request_root(
+        &mut self,
+        trace_id: String,
+        parent_id: String,
+    ) -> Vec<TraceStoreEvent> {
+        let now = Instant::now();
+        self.seen_trace_ids.insert(trace_id.clone());
+
+        let Some(state) = self.sequences.get_mut(&trace_id) else {
+            log::debug!(
+                "Ignoring OTel request root registration for unknown trace {trace_id}; sequence was not active"
+            );
+            return vec![TraceStoreEvent::RequestRootUnknownTrace];
+        };
+
+        match state.register_parent_id(parent_id, now) {
+            RootRegistrationResult::Registered => vec![TraceStoreEvent::RequestRootRegistered],
+            RootRegistrationResult::RegisteredAfterSpan => vec![
+                TraceStoreEvent::RequestRootRegistered,
+                TraceStoreEvent::RequestRootRegisteredAfterSpan,
+                TraceStoreEvent::RootSeen,
+            ],
+            RootRegistrationResult::Duplicate => Vec::new(),
+        }
+    }
+
+    pub(crate) fn finish_sequence(&mut self, trace_id: String) -> Vec<TraceStoreEvent> {
+        let now = Instant::now();
+        self.seen_trace_ids.insert(trace_id.clone());
+
+        let Some(state) = self.sequences.get_mut(&trace_id) else {
+            log::debug!(
+                "Ignoring OTel sequence finish for unknown trace {trace_id}; sequence was not active"
+            );
+            return vec![TraceStoreEvent::SequenceFinishUnknownTrace];
+        };
+
+        state.finish(now);
+        vec![TraceStoreEvent::SequenceFinished]
+    }
+
+    pub(crate) fn ingest_spans(
+        &mut self,
+        spans: Vec<ParsedSpan>,
+        coverage_state: &mut OtelCoverageState,
+    ) -> Vec<TraceStoreEvent> {
+        let mut events = Vec::new();
+        let now = Instant::now();
+
+        for span in spans {
+            let trace_id = span.trace_id.clone();
+            self.seen_trace_ids.insert(trace_id.clone());
+
+            if let Some(state) = self.sequences.get_mut(&trace_id) {
+                let result = state.process_span(span, coverage_state, now);
+                Self::push_span_events(&mut events, result);
+                if let Some(candidate) = state.maybe_promotion(now) {
+                    events.push(TraceStoreEvent::Promotion {
+                        trace_id,
+                        candidate,
+                    });
+                }
+                continue;
+            }
+
+            if self.evicted_trace_ids.contains_key(&trace_id) {
+                events.push(TraceStoreEvent::LateAfterEviction);
+            } else {
+                self.buffer_orphan_span(trace_id, span, now, &mut events);
+            }
+        }
+
+        events
+    }
+
+    pub(crate) fn drain_timeouts(
+        &mut self,
+        retention_window: Duration,
+        max_active_sequences: usize,
+    ) -> Vec<TraceStoreEvent> {
+        let now = Instant::now();
+        let mut expired_orphan_trace_ids = Vec::new();
+        for (trace_id, orphan_trace) in &self.orphan_traces {
+            if now.duration_since(orphan_trace.last_update) >= retention_window {
+                expired_orphan_trace_ids.push(trace_id.clone());
+            }
+        }
+
+        let mut events = Vec::new();
+        for trace_id in expired_orphan_trace_ids {
+            if let Some(orphan_trace) = self.orphan_traces.remove(&trace_id) {
+                self.buffered_orphan_spans = self
+                    .buffered_orphan_spans
+                    .saturating_sub(orphan_trace.spans.len());
+                for _ in orphan_trace.spans {
+                    events.push(TraceStoreEvent::OrphanSpan);
+                    events.push(TraceStoreEvent::OrphanSpanExpired);
+                }
+            }
+        }
+
+        let mut evict_trace_ids = Vec::new();
+
+        for (trace_id, state) in &self.sequences {
+            let should_evict = if let Some(finished_at) = state.finished_at {
+                now.duration_since(finished_at) >= retention_window
+            } else {
+                now.duration_since(state.started_at) >= retention_window
+            };
+
+            if should_evict {
+                evict_trace_ids.push(trace_id.clone());
+            }
+        }
+
+        for trace_id in evict_trace_ids {
+            let Some(state) = self.sequences.remove(&trace_id) else {
+                continue;
+            };
+            events.extend(self.evict_state(state, now, EvictionReason::Age));
+        }
+
+        if self.sequences.len() > max_active_sequences {
+            let overflow = self.sequences.len() - max_active_sequences;
+            let mut candidates: Vec<_> = self
+                .sequences
+                .iter()
+                .map(|(trace_id, state)| {
+                    let priority = match (state.finished_at.is_some(), state.promotion_emitted) {
+                        (true, false) => 0,
+                        (true, true) => 1,
+                        (false, _) => 2,
+                    };
+                    (trace_id.clone(), priority, state.last_update)
+                })
+                .collect();
+            candidates.sort_by_key(|(_, priority, last_update)| (*priority, *last_update));
+
+            for (trace_id, _, _) in candidates.into_iter().take(overflow) {
+                let Some(state) = self.sequences.remove(&trace_id) else {
+                    continue;
+                };
+                events.extend(self.evict_state(state, now, EvictionReason::Capacity));
+            }
+        }
+
+        events
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_count(&self) -> usize {
+        self.sequences.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_open_count(&self) -> usize {
+        self.sequences
+            .values()
+            .filter(|state| state.finished_at.is_none())
+            .count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn buffered_orphan_span_count(&self) -> usize {
+        self.buffered_orphan_spans
+    }
+
+    fn buffer_orphan_span(
+        &mut self,
+        trace_id: String,
+        span: ParsedSpan,
+        now: Instant,
+        events: &mut Vec<TraceStoreEvent>,
+    ) {
+        while self.buffered_orphan_spans >= MAX_BUFFERED_ORPHAN_SPANS
+            || (!self.orphan_traces.contains_key(&trace_id)
+                && self.orphan_traces.len() >= MAX_BUFFERED_ORPHAN_TRACES)
+        {
+            let Some(oldest_trace_id) = self.oldest_orphan_trace_id() else {
+                break;
+            };
+            if let Some(orphan_trace) = self.orphan_traces.remove(&oldest_trace_id) {
+                self.buffered_orphan_spans = self
+                    .buffered_orphan_spans
+                    .saturating_sub(orphan_trace.spans.len());
+                for _ in orphan_trace.spans {
+                    events.push(TraceStoreEvent::OrphanSpan);
+                    events.push(TraceStoreEvent::OrphanSpanCapacityDropped);
+                }
+            }
+        }
+
+        let orphan_trace = self
+            .orphan_traces
+            .entry(trace_id)
+            .or_insert_with(|| OrphanTrace {
+                spans: Vec::new(),
+                first_seen: now,
+                last_update: now,
+            });
+        orphan_trace.last_update = now;
+        orphan_trace.spans.push(span);
+        self.buffered_orphan_spans = self.buffered_orphan_spans.saturating_add(1);
+        events.push(TraceStoreEvent::OrphanSpanBuffered);
+    }
+
+    fn oldest_orphan_trace_id(&self) -> Option<String> {
+        self.orphan_traces
+            .iter()
+            .min_by_key(|(_, orphan_trace)| orphan_trace.first_seen)
+            .map(|(trace_id, _)| trace_id.clone())
+    }
+
+    fn evict_state(
+        &mut self,
+        state: SequenceState,
+        now: Instant,
+        reason: EvictionReason,
+    ) -> Vec<TraceStoreEvent> {
+        let trace_id = state.trace_id.clone();
+        self.evicted_trace_ids.insert(trace_id.clone(), reason);
+
+        let expected_parent_ids = state.expected_parent_count();
+        let seen_parent_ids = state.seen_parent_count();
+        let lifetime = now.duration_since(state.started_at);
+        let mut events = vec![TraceStoreEvent::Evicted {
+            trace_id: trace_id.clone(),
+            expected_parent_ids,
+            seen_parent_ids,
+            lifetime,
+            was_novel: state.novelty_seen,
+            reason,
+        }];
+
+        if state.novelty_seen {
+            return events;
+        }
+
+        if state.spans_seen == 0 {
+            events.push(TraceStoreEvent::Dropped {
+                trace_id,
+                expected_parent_ids,
+                seen_parent_ids,
+                waited: lifetime,
+            });
+        } else {
+            events.push(TraceStoreEvent::NonNovel {
+                trace_id,
+                expected_parent_ids,
+                seen_parent_ids,
+            });
+        }
+
+        events
+    }
+
+    fn push_span_events(events: &mut Vec<TraceStoreEvent>, result: SpanProcessResult) {
+        if result.newly_seen_root {
+            events.push(TraceStoreEvent::RootSeen);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coverage_clients::otel::{coverage::OtelCoverageState, types::OtelSpanKind};
+
+    fn span(
+        trace_id: &str,
+        service: &str,
+        name: &str,
+        span_id: &str,
+        parent_span_id: &str,
+    ) -> ParsedSpan {
+        ParsedSpan {
+            service_namespace: None,
+            service: service.to_owned(),
+            name: name.to_owned(),
+            kind: OtelSpanKind::Internal,
+            http_request_method: None,
+            http_route: None,
+            url_template: None,
+            rpc_system_name: None,
+            rpc_method: None,
+            trace_id: trace_id.to_owned(),
+            span_id: span_id.to_owned(),
+            parent_span_id: parent_span_id.to_owned(),
+            start_time_unix_nano: 0,
+            end_time_unix_nano: 1,
+        }
+    }
+
+    fn start(
+        store: &mut TraceStore,
+        coverage: &mut OtelCoverageState,
+        trace_id: &str,
+    ) -> Vec<TraceStoreEvent> {
+        store.start_sequence(trace_id.to_owned(), 1, OpenApiInput(vec![]), coverage)
+    }
+
+    fn register(store: &mut TraceStore, trace_id: &str, parent_id: &str) -> Vec<TraceStoreEvent> {
+        store.register_request_root(trace_id.to_owned(), parent_id.to_owned())
+    }
+
+    fn finish(store: &mut TraceStore, trace_id: &str) -> Vec<TraceStoreEvent> {
+        store.finish_sequence(trace_id.to_owned())
+    }
+
+    fn has_promotion(events: &[TraceStoreEvent]) -> bool {
+        events
+            .iter()
+            .any(|event| matches!(event, TraceStoreEvent::Promotion { .. }))
+    }
+
+    #[test]
+    fn started_sequence_processes_spans_before_finish() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        register(&mut store, "trace-1", "parent-1");
+        let events = store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "child", "parent-1")],
+            &mut coverage,
+        );
+
+        assert!(has_promotion(&events));
+        assert_eq!(store.active_open_count(), 1);
+    }
+
+    #[test]
+    fn closed_sequence_evicts_after_retention_window() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "root-span", "parent-1")],
+            &mut coverage,
+        );
+        finish(&mut store, "trace-1");
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(
+            store
+                .drain_timeouts(Duration::from_millis(1), 100)
+                .into_iter()
+                .any(|event| matches!(
+                    event,
+                    TraceStoreEvent::Evicted {
+                        reason: EvictionReason::Age,
+                        ..
+                    }
+                ))
+        );
+        assert_eq!(store.pending_count(), 0);
+    }
+
+    #[test]
+    fn closed_sequence_stays_active_before_retention_window() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "root-span", "parent-1")],
+            &mut coverage,
+        );
+        finish(&mut store, "trace-1");
+        std::thread::sleep(Duration::from_millis(5));
+
+        assert!(
+            store
+                .drain_timeouts(Duration::from_secs(60), 100)
+                .is_empty()
+        );
+        assert_eq!(store.pending_count(), 1);
+    }
+
+    #[test]
+    fn capacity_eviction_drops_oldest_closed_sequence_first() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        finish(&mut store, "trace-1");
+        std::thread::sleep(Duration::from_millis(1));
+        start(&mut store, &mut coverage, "trace-2");
+        finish(&mut store, "trace-2");
+        start(&mut store, &mut coverage, "trace-3");
+
+        let events = store.drain_timeouts(Duration::from_secs(60), 2);
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::Evicted { trace_id, reason: EvictionReason::Capacity, .. } if trace_id == "trace-1"))
+        );
+        assert_eq!(store.pending_count(), 2);
+    }
+
+    #[test]
+    fn late_span_after_eviction_is_counted_and_ignored_for_guidance() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        finish(&mut store, "trace-1");
+        std::thread::sleep(Duration::from_millis(5));
+        store.drain_timeouts(Duration::from_millis(1), 100);
+
+        let events = store.ingest_spans(
+            vec![span("trace-1", "svc", "late", "late-span", "parent-1")],
+            &mut coverage,
+        );
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::LateAfterEviction))
+        );
+        assert!(!has_promotion(&events));
+        assert_eq!(coverage.coverage_ratio(), (0, 0));
+    }
+
+    #[test]
+    fn orphan_span_is_buffered_before_sequence_start() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        let events = store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "root-span", "parent-1")],
+            &mut coverage,
+        );
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::OrphanSpanBuffered))
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::OrphanSpan))
+        );
+        assert!(!has_promotion(&events));
+    }
+
+    #[test]
+    fn buffered_orphan_span_reassociates_on_sequence_start() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "root-span", "parent-1")],
+            &mut coverage,
+        );
+        let events = start(&mut store, &mut coverage, "trace-1");
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::OrphanSpanReassociated))
+        );
+        assert!(has_promotion(&events));
+        assert_eq!(coverage.coverage_ratio(), (1, 0));
+    }
+
+    #[test]
+    fn buffered_orphan_span_expires_as_true_orphan() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "root-span", "parent-1")],
+            &mut coverage,
+        );
+        std::thread::sleep(Duration::from_millis(5));
+        let events = store.drain_timeouts(Duration::from_millis(1), 100);
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::OrphanSpan))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::OrphanSpanExpired))
+        );
+    }
+
+    #[test]
+    fn capacity_dropped_orphan_span_counts_as_orphan_loss() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        let mut events = Vec::new();
+        for index in 0..=MAX_BUFFERED_ORPHAN_TRACES {
+            events.extend(store.ingest_spans(
+                vec![span(
+                    &format!("trace-{index}"),
+                    "svc",
+                    "root",
+                    &format!("root-span-{index}"),
+                    "parent-1",
+                )],
+                &mut coverage,
+            ));
+        }
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::OrphanSpan))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::OrphanSpanCapacityDropped))
+        );
+        assert_eq!(
+            store.buffered_orphan_span_count(),
+            MAX_BUFFERED_ORPHAN_TRACES
+        );
+    }
+
+    #[test]
+    fn promoted_sequence_learns_later_novelty_without_duplicate_promotion() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        register(&mut store, "trace-1", "parent-1");
+        let first_events = store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "root-span", "parent-1")],
+            &mut coverage,
+        );
+        assert!(has_promotion(&first_events));
+        finish(&mut store, "trace-1");
+
+        let late_events = store.ingest_spans(
+            vec![span("trace-1", "svc", "late-child", "child", "root-span")],
+            &mut coverage,
+        );
+
+        assert!(!has_promotion(&late_events));
+        assert_eq!(coverage.coverage_ratio(), (3, 0));
+    }
+
+    #[test]
+    fn multiple_request_roots_learn_multiple_novelties_with_one_promotion() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        register(&mut store, "trace-1", "request-parent-1");
+        register(&mut store, "trace-1", "request-parent-2");
+
+        let first_events = store.ingest_spans(
+            vec![span(
+                "trace-1",
+                "svc",
+                "GET /one",
+                "root-1",
+                "request-parent-1",
+            )],
+            &mut coverage,
+        );
+        let second_events = store.ingest_spans(
+            vec![span(
+                "trace-1",
+                "svc",
+                "POST /two",
+                "root-2",
+                "request-parent-2",
+            )],
+            &mut coverage,
+        );
+
+        assert!(has_promotion(&first_events));
+        assert!(!has_promotion(&second_events));
+        assert_eq!(coverage.coverage_ratio(), (2, 0));
+    }
+
+    #[test]
+    fn out_of_order_child_resolves_edge_when_parent_arrives() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        register(&mut store, "trace-1", "request-parent");
+        store.ingest_spans(
+            vec![span("trace-1", "svc", "child", "child-span", "root-span")],
+            &mut coverage,
+        );
+        store.ingest_spans(
+            vec![span(
+                "trace-1",
+                "svc",
+                "root",
+                "root-span",
+                "request-parent",
+            )],
+            &mut coverage,
+        );
+
+        assert_eq!(coverage.coverage_ratio(), (3, 0));
+    }
+    #[test]
+    fn root_registered_after_span_counts_root_seen_retroactively() {
+        let mut store = TraceStore::default();
+        let mut coverage = OtelCoverageState::default();
+
+        start(&mut store, &mut coverage, "trace-1");
+        store.ingest_spans(
+            vec![span("trace-1", "svc", "root", "root-span", "parent-1")],
+            &mut coverage,
+        );
+        let events = register(&mut store, "trace-1", "parent-1");
+
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::RequestRootRegisteredAfterSpan))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::RootSeen))
+        );
+    }
+
+    #[test]
+    fn unknown_lifecycle_messages_are_counted() {
+        let mut store = TraceStore::default();
+
+        let root_events = register(&mut store, "missing-trace", "parent-1");
+        let finish_events = finish(&mut store, "missing-trace");
+
+        assert!(
+            root_events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::RequestRootUnknownTrace))
+        );
+        assert!(
+            finish_events
+                .iter()
+                .any(|event| matches!(event, TraceStoreEvent::SequenceFinishUnknownTrace))
+        );
+    }
+}

--- a/src/coverage_clients/otel/trace_store.rs
+++ b/src/coverage_clients/otel/trace_store.rs
@@ -1,3 +1,7 @@
+//! Correlates asynchronously-arriving OTel spans with the request sequence that produced
+//! them, tracking expected/seen request roots, buffering orphan spans, and evicting stale or
+//! overflowing sequences.
+
 use std::{
     collections::{HashMap, HashSet},
     time::{Duration, Instant},

--- a/src/coverage_clients/otel/trace_store.rs
+++ b/src/coverage_clients/otel/trace_store.rs
@@ -7,12 +7,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::input::OpenApiInput;
-
 use super::{
     coverage::{EdgeKey, OtelCoverageState, SpanKey},
     types::{ParsedSpan, PromotionCandidate},
 };
+use crate::input::OpenApiInput;
 
 const MAX_BUFFERED_ORPHAN_TRACES: usize = 10_000;
 const MAX_BUFFERED_ORPHAN_SPANS: usize = 50_000;

--- a/src/coverage_clients/otel/types.rs
+++ b/src/coverage_clients/otel/types.rs
@@ -1,0 +1,123 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use crate::{input::OpenApiInput, reporting::OtelTraceProcessingStats};
+
+pub(crate) const DEFAULT_ARBITER_QUEUE_CAPACITY: usize = 65_536;
+pub(crate) const DEFAULT_SEQUENCE_RETENTION_WINDOW: Duration = Duration::from_secs(120);
+pub(crate) const DEFAULT_MAX_ACTIVE_SEQUENCES: usize = 100_000;
+pub(crate) const DEFAULT_ARBITER_TICK_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Shared development metrics for the built-in OTel receiver and arbiter.
+pub type SharedOtelTraceProcessingMetrics = Arc<Mutex<OtelTraceProcessingStats>>;
+
+/// Create a shared accumulator for OTel receiver/arbiter metrics.
+pub fn new_otel_trace_processing_metrics() -> SharedOtelTraceProcessingMetrics {
+    Arc::new(Mutex::new(OtelTraceProcessingStats::default()))
+}
+
+/// Read a snapshot of the shared OTel receiver/arbiter metrics.
+pub fn read_otel_trace_processing_metrics(
+    metrics: &SharedOtelTraceProcessingMetrics,
+) -> OtelTraceProcessingStats {
+    *metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned")
+}
+
+pub(crate) fn record_engine_queue_depth(
+    metrics: &SharedOtelTraceProcessingMetrics,
+    queue_depth: usize,
+) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    let queue_depth = queue_depth as u64;
+    metrics.engine_queue_depth = queue_depth;
+    metrics.engine_queue_high_watermark = metrics.engine_queue_high_watermark.max(queue_depth);
+}
+
+pub(crate) fn record_engine_backpressure(metrics: &SharedOtelTraceProcessingMetrics) {
+    let mut metrics = metrics
+        .lock()
+        .expect("otel trace processing metrics mutex poisoned");
+    metrics.engine_backpressure = metrics.engine_backpressure.saturating_add(1);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum OtelSpanKind {
+    Unspecified,
+    Internal,
+    Server,
+    Client,
+    Producer,
+    Consumer,
+}
+
+impl OtelSpanKind {
+    pub(crate) fn from_otlp_kind(kind: i32) -> Self {
+        match kind {
+            1 => Self::Internal,
+            2 => Self::Server,
+            3 => Self::Client,
+            4 => Self::Producer,
+            5 => Self::Consumer,
+            _ => Self::Unspecified,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Unspecified => "unspecified",
+            Self::Internal => "internal",
+            Self::Server => "server",
+            Self::Client => "client",
+            Self::Producer => "producer",
+            Self::Consumer => "consumer",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedSpan {
+    pub service_namespace: Option<String>,
+    pub service: String,
+    pub name: String,
+    pub kind: OtelSpanKind,
+    pub http_request_method: Option<String>,
+    pub http_route: Option<String>,
+    pub url_template: Option<String>,
+    pub rpc_system_name: Option<String>,
+    pub rpc_method: Option<String>,
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: String,
+    pub start_time_unix_nano: u64,
+    pub end_time_unix_nano: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PromotionCandidate {
+    pub submission_id: u64,
+    pub input: OpenApiInput,
+}
+
+#[derive(Debug)]
+pub(crate) enum ArbiterMessage {
+    SequenceStarted {
+        submission_id: u64,
+        input: OpenApiInput,
+        trace_id: String,
+    },
+    RequestRootRegistered {
+        trace_id: String,
+        parent_id: String,
+    },
+    SequenceFinished {
+        trace_id: String,
+    },
+    ReceivedSpans(Vec<ParsedSpan>),
+    Shutdown,
+}

--- a/src/coverage_clients/otel/types.rs
+++ b/src/coverage_clients/otel/types.rs
@@ -1,3 +1,6 @@
+//! Shared types, defaults, and metrics helpers used across the OTel coverage client, its
+//! OTLP receivers, the trace store, and the arbiter.
+
 use std::{
     sync::{Arc, Mutex},
     time::Duration,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -3,6 +3,7 @@
 
 use std::{
     borrow::Cow,
+    collections::{HashSet, hash_map::DefaultHasher},
     marker::PhantomData,
     sync::{
         Arc, Mutex,
@@ -15,6 +16,7 @@ use libafl::{
     corpus::Corpus,
     events::{Event, EventFirer, EventRestarter, EventWithStats, ExecStats, SendExiting},
     executors::{Executor, ExitKind, HasObservers},
+    fuzzer::Evaluator,
     monitors::stats::{AggregatorOps, UserStats, UserStatsValue},
     observers::ObserversTuple,
     state::{HasCorpus, HasExecutions, HasSolutions, Stoppable},
@@ -22,12 +24,17 @@ use libafl::{
 use libafl_bolts::{current_time, prelude::RefIndexable};
 use reqwest::blocking::Client;
 use reqwest_cookie_store::CookieStoreMutex;
+use std::hash::{Hash, Hasher};
 use strum::IntoDiscriminant;
 
 use crate::{
     authentication::{Authentication, build_http_client},
-    configuration::Configuration,
-    coverage_clients::{CoverageClient, endpoint::EndpointCoverageClient},
+    configuration::{Configuration, CoverageConfiguration},
+    coverage_clients::{
+        CoverageClient,
+        endpoint::EndpointCoverageClient,
+        otel::{SharedOtelTraceProcessingMetrics, read_otel_trace_processing_metrics},
+    },
     input::{OpenApiInput, OpenApiRequest},
     openapi::{
         build_request::build_request_from_input,
@@ -65,6 +72,33 @@ fn duration_as_us(start: Instant) -> u64 {
 
 type FuzzerState = crate::state::OpenApiFuzzerState<OpenApiInput>;
 
+#[derive(Default)]
+struct KnownCorpusInputs {
+    seen_hashes: HashSet<u64>,
+}
+
+impl KnownCorpusInputs {
+    fn input_hash(input: &OpenApiInput) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        input.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn ingest_state(&mut self, state: &FuzzerState) {
+        for id in state.corpus().ids() {
+            if let Ok(testcase) = state.corpus().get(id)
+                && let Some(input) = testcase.borrow().input()
+            {
+                self.seen_hashes.insert(Self::input_hash(input));
+            }
+        }
+    }
+
+    fn mark_new(&mut self, input: &OpenApiInput) -> bool {
+        self.seen_hashes.insert(Self::input_hash(input))
+    }
+}
+
 /// The Executor for sending Sequences of OpenAPI requests to the target.
 /// It is responsible for executing inputs chosen by the fuzzer, and tracking
 /// statistics about coverage and errors.
@@ -84,6 +118,9 @@ where
     coverage_client: Box<dyn CoverageClient>,
     endpoint_client: Arc<Mutex<EndpointCoverageClient>>,
     reporter: Option<MySqLite>,
+    known_corpus_inputs: KnownCorpusInputs,
+    otel_trace_processing_metrics: Option<SharedOtelTraceProcessingMetrics>,
+    replaying_otel_promotion: bool,
 
     manual_interrupt: Arc<AtomicBool>,
     maybe_timeout_secs: Option<Duration>,
@@ -145,6 +182,7 @@ where
         config: &'static Configuration,
         coverage_client: Box<dyn CoverageClient>,
         endpoint_client: Arc<Mutex<EndpointCoverageClient>>,
+        otel_trace_processing_metrics: Option<SharedOtelTraceProcessingMetrics>,
     ) -> anyhow::Result<Self> {
         let (authentication, cookie_store, http_client) = build_http_client(api)?;
 
@@ -161,6 +199,9 @@ where
             coverage_client,
             endpoint_client,
             reporter: crate::reporting::sqlite::get_reporter(config, api)?,
+            known_corpus_inputs: KnownCorpusInputs::default(),
+            otel_trace_processing_metrics,
+            replaying_otel_promotion: false,
 
             manual_interrupt: setup_interrupt()?,
             maybe_timeout_secs: config.timeout.map(|t| Duration::from_secs(t.get())),
@@ -203,6 +244,37 @@ where
         }
     }
 
+    fn current_window_rates(&self) -> (f64, f64) {
+        let elapsed = self
+            .last_window_time
+            .elapsed()
+            .as_secs_f64()
+            .max(f64::EPSILON);
+        (
+            (self.inputs_tested - self.last_window_seqs) as f64 / elapsed,
+            (self.performed_requests - self.last_window_reqs) as f64 / elapsed,
+        )
+    }
+
+    fn write_stats_snapshot(&self, state: &FuzzerState, seq_per_sec: f64, req_per_sec: f64) {
+        let otel_trace_processing_stats = self
+            .otel_trace_processing_metrics
+            .as_ref()
+            .map(read_otel_trace_processing_metrics)
+            .unwrap_or_default();
+
+        self.reporter.report_stats(CampaignStats {
+            seq_per_sec,
+            req_per_sec,
+            requests_completed_total: self.performed_requests,
+            corpus_size: state.corpus().count().try_into().unwrap_or(u32::MAX),
+            objectives: state.solutions().count().try_into().unwrap_or(u32::MAX),
+            sequence_stop_stats: self.sequence_stop_stats,
+            sequence_timing_stats: self.sequence_timing_stats,
+            otel_trace_processing_stats,
+        });
+    }
+
     /// Executes the given input, tracking and using response parameters and verifying responses.
     /// Returns the target's performance as ExitKind, and the number of requests successfully
     /// executed (i.e. before an error occurred).
@@ -211,6 +283,10 @@ where
         self.inputs_tested += 1;
         let mut performed_requests = 0;
         let mut stop_reason = SequenceStopReason::Completed;
+
+        if let Some(guidance) = self.coverage_client.delayed_guidance() {
+            guidance.start_request_sequence(inputs);
+        }
 
         let mut parameter_feedback = ParameterFeedback::new(inputs.0.len());
         log::debug!("Sending {} requests", inputs.0.len());
@@ -250,7 +326,17 @@ where
                     log::error!("Error building request: {err}");
                     continue;
                 }
-                Ok(r) => r.timeout(Duration::from_millis(self.config.request_timeout)),
+                Ok(r) => {
+                    let mut builder = r.timeout(Duration::from_millis(self.config.request_timeout));
+                    if let Some(traceparent) = self
+                        .coverage_client
+                        .delayed_guidance()
+                        .and_then(|guidance| guidance.traceparent_for_request())
+                    {
+                        builder = builder.header("traceparent", traceparent);
+                    }
+                    builder
+                }
             };
 
             let request_built = match request_builder.build() {
@@ -405,13 +491,13 @@ where
     fn post_exec<EM>(
         &mut self,
         state: &mut FuzzerState,
-        _input: &OpenApiInput,
+        input: &OpenApiInput,
         event_manager: &mut EM,
     ) where
         EM: EventFirer<OpenApiInput, FuzzerState> + EventRestarter<FuzzerState>,
     {
         let code_coverage_phase_start = Instant::now();
-        self.coverage_client.fetch_coverage(true);
+        self.coverage_client.finish_request_sequence(input);
         let (covered, total) = self.coverage_client.max_coverage_ratio();
         Self::add_timing(
             &mut self.sequence_timing_stats.code_coverage_phase_us,
@@ -436,7 +522,10 @@ where
                 state,
                 event_manager,
                 "wuppiefuzz_code_coverage",
-                UserStatsValue::Ratio(covered, total),
+                match self.config.coverage_configuration {
+                    CoverageConfiguration::Otel { .. } => UserStatsValue::Number(covered),
+                    _ => UserStatsValue::Ratio(covered, total),
+                },
             );
         }
 
@@ -456,7 +545,6 @@ where
             .duration_since(self.last_window_time)
             .as_secs();
         if diff > CLIENT_STATS_TIME_WINDOW_SECS {
-            self.last_window_time = current_instant;
             // send the request stats to the event manager for use in the monitor
             update_stats(
                 state,
@@ -465,17 +553,9 @@ where
                 UserStatsValue::Number(self.performed_requests),
             );
 
-            let seq_delta = self.inputs_tested - self.last_window_seqs;
-            let req_delta = self.performed_requests - self.last_window_reqs;
-            self.reporter.report_stats(CampaignStats {
-                seq_per_sec: seq_delta as f64 / diff as f64,
-                req_per_sec: req_delta as f64 / diff as f64,
-                requests_completed_total: self.performed_requests,
-                corpus_size: state.corpus().count().try_into().unwrap_or(u32::MAX),
-                objectives: state.solutions().count().try_into().unwrap_or(u32::MAX),
-                sequence_stop_stats: self.sequence_stop_stats,
-                sequence_timing_stats: self.sequence_timing_stats,
-            });
+            let (seq_per_sec, req_per_sec) = self.current_window_rates();
+            self.write_stats_snapshot(state, seq_per_sec, req_per_sec);
+            self.last_window_time = current_instant;
             self.last_window_seqs = self.inputs_tested;
             self.last_window_reqs = self.performed_requests;
         }
@@ -511,6 +591,69 @@ where
             &mut self.sequence_timing_stats.post_exec_reporting_us,
             post_exec_reporting_start,
         );
+    }
+
+    pub(crate) fn report_final_coverage_and_stats(&mut self, state: &FuzzerState) {
+        let (covered, total) = self.coverage_client.max_coverage_ratio();
+        let (e_covered, e_total) = self.endpoint_client.max_coverage_ratio();
+        self.reporter.report_coverage(
+            covered.try_into().unwrap_or(u32::MAX),
+            total.try_into().unwrap_or(u32::MAX),
+            e_covered.try_into().unwrap_or(u32::MAX),
+            e_total.try_into().unwrap_or(u32::MAX),
+        );
+        let (seq_per_sec, req_per_sec) = self.current_window_rates();
+        self.write_stats_snapshot(state, seq_per_sec, req_per_sec);
+    }
+
+    pub(crate) fn drain_otel_promotions<FZ, EM>(
+        &mut self,
+        fuzzer: &mut FZ,
+        state: &mut FuzzerState,
+        event_manager: &mut EM,
+    ) -> Result<(), libafl::Error>
+    where
+        FZ: Evaluator<Self, EM, OpenApiInput, FuzzerState>,
+        EM: EventFirer<OpenApiInput, FuzzerState> + EventRestarter<FuzzerState> + SendExiting,
+    {
+        let Some(guidance) = self.coverage_client.delayed_guidance() else {
+            return Ok(());
+        };
+
+        self.known_corpus_inputs.ingest_state(state);
+        let promoted_inputs = guidance.drain_promoted_inputs();
+        if promoted_inputs.is_empty() {
+            return Ok(());
+        }
+
+        for input in promoted_inputs {
+            if !self.known_corpus_inputs.mark_new(&input) {
+                continue;
+            }
+
+            let corpus_before = state.corpus().count();
+
+            self.replaying_otel_promotion = true;
+            if let Some(guidance) = self.coverage_client.delayed_guidance() {
+                guidance.set_replay_promotion(true);
+            }
+
+            let result = fuzzer.add_input(state, self, event_manager, input);
+
+            if let Some(guidance) = self.coverage_client.delayed_guidance() {
+                guidance.set_replay_promotion(false);
+            }
+            self.replaying_otel_promotion = false;
+
+            result?;
+
+            let accepted = state.corpus().count() > corpus_before;
+            if accepted && let Some(metrics) = &self.otel_trace_processing_metrics {
+                metrics.lock().unwrap().promoted_inputs_added += 1;
+            }
+        }
+
+        Ok(())
     }
 
     /// Uses the embedded coverage clients to generate a coverage report

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -1,6 +1,10 @@
 #[cfg(windows)]
 use std::ptr::write_volatile;
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 #[allow(unused_imports)]
@@ -76,7 +80,20 @@ pub fn fuzz() -> Result<()> {
 
     // Observers & feedback initialization
     let mut endpoint_coverage_client = setup_endpoint_coverage(api)?;
-    let mut code_coverage_client = setup_line_coverage(config, &report_path)?;
+    let (mut code_coverage_client, otel_trace_processing_metrics) =
+        setup_line_coverage(config, &report_path)?;
+
+    match config.coverage_configuration {
+        crate::configuration::CoverageConfiguration::Endpoint => {
+            log::info!("Coverage guidance: endpoint coverage only (no instrumentation)");
+        }
+        crate::configuration::CoverageConfiguration::Otel { .. } => {
+            log::info!("Coverage guidance: endpoint coverage plus OpenTelemetry spans");
+        }
+        _ => {
+            log::info!("Coverage guidance: endpoint coverage plus source-code coverage");
+        }
+    }
     let combined_map_observer: CombinedMapObserverType<'_> =
         construct_observer(&mut endpoint_coverage_client, &mut code_coverage_client);
     let time_observer = TimeObserver::new("time");
@@ -119,6 +136,7 @@ pub fn fuzz() -> Result<()> {
         config,
         code_coverage_client,
         endpoint_coverage_client,
+        otel_trace_processing_metrics,
     )?;
 
     // Minimize corpus
@@ -128,6 +146,8 @@ pub fn fuzz() -> Result<()> {
     log::debug!("Start fuzzing loop");
     executor.start_timer();
     loop {
+        executor.drain_otel_promotions(&mut fuzzer, &mut state, &mut mgr)?;
+
         match fuzzer.fuzz_one(&mut stages, &mut executor, &mut state, &mut mgr) {
             Ok(_) => (),
             Err(libafl_bolts::Error::ShuttingDown) => {
@@ -138,6 +158,9 @@ pub fn fuzz() -> Result<()> {
                 return Err(err).context("Error in the fuzz loop");
             }
         };
+
+        executor.drain_otel_promotions(&mut fuzzer, &mut state, &mut mgr)?;
+
         // send update of execution data to the monitor
         let executions = *state.executions();
         if let Err(e) = mgr.fire(
@@ -149,6 +172,14 @@ pub fn fuzz() -> Result<()> {
     }
 
     // Coverage reporting
+    if matches!(
+        config.coverage_configuration,
+        crate::configuration::CoverageConfiguration::Otel { .. }
+    ) {
+        // Give batched OTEL exporters a short grace period before the final snapshot.
+        thread::sleep(Duration::from_secs(6));
+    }
+    executor.report_final_coverage_and_stats(&state);
     executor.generate_coverage_report_if_path(report_path.as_deref());
 
     Ok(())

--- a/src/reporting/mod.rs
+++ b/src/reporting/mod.rs
@@ -10,6 +10,43 @@ use crate::{
 
 pub mod sqlite;
 
+/// Coarse-grained OTel receiver/arbiter stats for dashboard reporting.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OtelTraceProcessingStats {
+    /// Number of OTLP requests accepted by the built-in receiver.
+    pub receiver_requests_ok: u64,
+    /// Number of OTLP requests rejected by the built-in receiver.
+    pub receiver_requests_rejected: u64,
+    /// Number of OTLP/HTTP requests that failed protobuf decoding.
+    pub receiver_requests_decode_error: u64,
+    /// Total number of spans handed from the receiver to the arbiter.
+    pub spans_received: u64,
+    /// Number of spans received after a sequence was evicted/dropped from guidance state.
+    pub spans_late_after_eviction: u64,
+    /// Number of request parent IDs registered across sequences.
+    pub sequence_roots_expected: u64,
+    /// Number of request root parent IDs observed in traces.
+    pub sequence_roots_seen: u64,
+    /// Number of completed sequences whose spans introduced new OTel coverage.
+    pub sequences_promoted: u64,
+    /// Number of delayed OTel promotion candidates that were actually added to the corpus.
+    pub promoted_inputs_added: u64,
+    /// Current number of unique OTel semantic span keys.
+    pub unique_span_keys: u64,
+    /// Current number of unique OTel semantic edge keys.
+    pub unique_edge_keys: u64,
+    /// Current OTEL engine queue depth.
+    pub engine_queue_depth: u64,
+    /// Highest observed OTEL engine queue depth.
+    pub engine_queue_high_watermark: u64,
+    /// Number of times producers observed OTEL engine backpressure.
+    pub engine_backpressure: u64,
+    /// Request root registrations for unknown traces.
+    pub request_roots_unknown_trace: u64,
+    /// Sequence finish messages for unknown traces.
+    pub sequence_finish_unknown_trace: u64,
+}
+
 /// Cumulative reasons why an input sequence either finished or stopped early.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SequenceStopStats {
@@ -67,6 +104,7 @@ pub struct CampaignStats {
     pub sequence_stop_stats: SequenceStopStats,
     /// Cumulative executor phase timing totals.
     pub sequence_timing_stats: SequenceTimingStats,
+    pub otel_trace_processing_stats: OtelTraceProcessingStats,
 }
 
 /// Creates and returns the report path for this run. It is typically of the form

--- a/src/reporting/sqlite.rs
+++ b/src/reporting/sqlite.rs
@@ -36,6 +36,63 @@ pub fn get_reporter(config: &Configuration, api: &Spec) -> Result<Option<MySqLit
 /// to disk, so batching amortises that cost across many writes.
 const BATCH_SIZE: u32 = 4096;
 
+const OTEL_STATS_COLUMNS: &[&str] = &[
+    "otel_receiver_requests_ok_total",
+    "otel_receiver_requests_rejected_total",
+    "otel_receiver_requests_decode_error_total",
+    "otel_spans_received_total",
+    "otel_spans_late_after_eviction_total",
+    "otel_sequence_roots_expected_total",
+    "otel_sequence_roots_seen_total",
+    "otel_sequences_promoted_total",
+    "otel_promoted_inputs_added_total",
+    "otel_unique_span_keys_total",
+    "otel_unique_edge_keys_total",
+    "otel_engine_queue_depth",
+    "otel_engine_queue_high_watermark",
+    "otel_engine_backpressure_total",
+    "otel_request_roots_unknown_trace_total",
+    "otel_sequence_finish_unknown_trace_total",
+];
+
+fn to_i64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+fn ensure_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> anyhow::Result<()> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .with_context(|| format!("Could not inspect `{table}` table"))?;
+    let existing = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if !existing
+        .iter()
+        .any(|existing_column| existing_column == column)
+    {
+        conn.execute(
+            &format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"),
+            [],
+        )
+        .with_context(|| format!("Could not add `{column}` column to `{table}` table"))?;
+    }
+
+    Ok(())
+}
+
+fn ensure_stats_columns(conn: &Connection) -> anyhow::Result<()> {
+    for column in OTEL_STATS_COLUMNS {
+        ensure_column(conn, "stats", column, "INTEGER NOT NULL DEFAULT 0")?;
+    }
+    Ok(())
+}
+
 pub struct MySqLite {
     conn: Connection,
     run_id: i64,
@@ -167,12 +224,30 @@ impl MySqLite {
                 `code_coverage_phase_us_total` INTEGER NOT NULL DEFAULT 0,
                 `endpoint_coverage_phase_us_total` INTEGER NOT NULL DEFAULT 0,
                 `post_exec_reporting_us_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_receiver_requests_ok_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_receiver_requests_rejected_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_receiver_requests_decode_error_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_spans_received_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_spans_late_after_eviction_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_sequence_roots_expected_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_sequence_roots_seen_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_sequences_promoted_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_promoted_inputs_added_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_unique_span_keys_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_unique_edge_keys_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_engine_queue_depth` INTEGER NOT NULL DEFAULT 0,
+                `otel_engine_queue_high_watermark` INTEGER NOT NULL DEFAULT 0,
+                `otel_engine_backpressure_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_request_roots_unknown_trace_total` INTEGER NOT NULL DEFAULT 0,
+                `otel_sequence_finish_unknown_trace_total` INTEGER NOT NULL DEFAULT 0,
                 `runid` INTEGER NOT NULL,
                 CONSTRAINT run_FK FOREIGN KEY (runid) REFERENCES runs(id)
             )",
             [],
         )
         .context("Could not create `stats` table")?;
+
+        ensure_stats_columns(&conn)?;
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS run_configuration (
@@ -414,6 +489,22 @@ impl Reporting<i64, OpenApiFuzzerStateType> for MySqLite {
                     code_coverage_phase_us_total,
                     endpoint_coverage_phase_us_total,
                     post_exec_reporting_us_total,
+                    otel_receiver_requests_ok_total,
+                    otel_receiver_requests_rejected_total,
+                    otel_receiver_requests_decode_error_total,
+                    otel_spans_received_total,
+                    otel_spans_late_after_eviction_total,
+                    otel_sequence_roots_expected_total,
+                    otel_sequence_roots_seen_total,
+                    otel_sequences_promoted_total,
+                    otel_promoted_inputs_added_total,
+                    otel_unique_span_keys_total,
+                    otel_unique_edge_keys_total,
+                    otel_engine_queue_depth,
+                    otel_engine_queue_high_watermark,
+                    otel_engine_backpressure_total,
+                    otel_request_roots_unknown_trace_total,
+                    otel_sequence_finish_unknown_trace_total,
                     runid
                 ) VALUES (
                     :seq_per_sec,
@@ -436,10 +527,28 @@ impl Reporting<i64, OpenApiFuzzerStateType> for MySqLite {
                     :code_coverage_phase_us_total,
                     :endpoint_coverage_phase_us_total,
                     :post_exec_reporting_us_total,
+                    :otel_receiver_requests_ok_total,
+                    :otel_receiver_requests_rejected_total,
+                    :otel_receiver_requests_decode_error_total,
+                    :otel_spans_received_total,
+                    :otel_spans_late_after_eviction_total,
+                    :otel_sequence_roots_expected_total,
+                    :otel_sequence_roots_seen_total,
+                    :otel_sequences_promoted_total,
+                    :otel_promoted_inputs_added_total,
+                    :otel_unique_span_keys_total,
+                    :otel_unique_edge_keys_total,
+                    :otel_engine_queue_depth,
+                    :otel_engine_queue_high_watermark,
+                    :otel_engine_backpressure_total,
+                    :otel_request_roots_unknown_trace_total,
+                    :otel_sequence_finish_unknown_trace_total,
                     :runid
                 )",
             )
             .expect("Could not prepare insert statement for stats");
+        let otel_trace_processing_stats = stats.otel_trace_processing_stats;
+
         insert_stmt
             .insert(named_params! {
                 ":seq_per_sec": stats.seq_per_sec,
@@ -462,6 +571,22 @@ impl Reporting<i64, OpenApiFuzzerStateType> for MySqLite {
                 ":code_coverage_phase_us_total": i64::try_from(stats.sequence_timing_stats.code_coverage_phase_us).unwrap_or(i64::MAX),
                 ":endpoint_coverage_phase_us_total": i64::try_from(stats.sequence_timing_stats.endpoint_coverage_phase_us).unwrap_or(i64::MAX),
                 ":post_exec_reporting_us_total": i64::try_from(stats.sequence_timing_stats.post_exec_reporting_us).unwrap_or(i64::MAX),
+                ":otel_receiver_requests_ok_total": to_i64(otel_trace_processing_stats.receiver_requests_ok),
+                ":otel_receiver_requests_rejected_total": to_i64(otel_trace_processing_stats.receiver_requests_rejected),
+                ":otel_receiver_requests_decode_error_total": to_i64(otel_trace_processing_stats.receiver_requests_decode_error),
+                ":otel_spans_received_total": to_i64(otel_trace_processing_stats.spans_received),
+                ":otel_spans_late_after_eviction_total": to_i64(otel_trace_processing_stats.spans_late_after_eviction),
+                ":otel_sequence_roots_expected_total": to_i64(otel_trace_processing_stats.sequence_roots_expected),
+                ":otel_sequence_roots_seen_total": to_i64(otel_trace_processing_stats.sequence_roots_seen),
+                ":otel_sequences_promoted_total": to_i64(otel_trace_processing_stats.sequences_promoted),
+                ":otel_promoted_inputs_added_total": to_i64(otel_trace_processing_stats.promoted_inputs_added),
+                ":otel_unique_span_keys_total": to_i64(otel_trace_processing_stats.unique_span_keys),
+                ":otel_unique_edge_keys_total": to_i64(otel_trace_processing_stats.unique_edge_keys),
+                ":otel_engine_queue_depth": to_i64(otel_trace_processing_stats.engine_queue_depth),
+                ":otel_engine_queue_high_watermark": to_i64(otel_trace_processing_stats.engine_queue_high_watermark),
+                ":otel_engine_backpressure_total": to_i64(otel_trace_processing_stats.engine_backpressure),
+                ":otel_request_roots_unknown_trace_total": to_i64(otel_trace_processing_stats.request_roots_unknown_trace),
+                ":otel_sequence_finish_unknown_trace_total": to_i64(otel_trace_processing_stats.sequence_finish_unknown_trace),
                 ":runid": self.run_id,
             })
             .expect("Could not insert stats into database");


### PR DESCRIPTION
Adds OpenTelemetry as a grey-box semantic feedback mode for WuppieFuzz

  Changes:
  - Adds an OTEL coverage configuration modee
  - Starts a local OTLP receiver for traces
  - Injects W3C traceparent headers into generated HTTP requests
  - Converts received spans into semantic span and edge coverage
  - Uses delayed promotion to replay OTEL-novel request sequences through the normal LibAFL corpus insertion path
  - Persists the OTEL metrics used by the dashboard
  
  This is related to the WuppieFuzz-dashboard PR #19 (https://github.com/TNO-S3/WuppieFuzz-dashboard/pull/19)