### PR TITLE
fix: Change stack size on windows to 8 MiB

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,12 @@
 dev-build = "build --no-default-features --features sequence-diagnostics"
 dev-run = "run --no-default-features --features sequence-diagnostics"
 dev-test = "test --no-default-features --features sequence-diagnostics"
+
+# Match the ~8 MiB main-thread stack Linux gets by default; Windows'
+# default of 1 MiB is too small for the recursive OpenAPI schema resolution
+# used during corpus generation.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/STACK:8388608"]
+
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "link-args=-Wl,--stack,8388608"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,16 @@ rustflags = ["-C", "link-args=/STACK:8388608"]
 
 [target.x86_64-pc-windows-gnu]
 rustflags = ["-C", "link-args=-Wl,--stack,8388608"]
+
+# Keep linker-level stack settings aligned across desktop targets.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-z,stack-size=8388608"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-z,stack-size=8388608"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-args=-Wl,-stack_size,0x800000"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-args=-Wl,-stack_size,0x800000"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Fixes
 
 - Occassional panic when duration is negative due to time corrections in [#346](https://github.com/TNO-S3/WuppieFuzz/pull/346)
+- Harmonize stack size of builds to prevent crashes in Windows [#360](https://github.com/TNO-S3/WuppieFuzz/pull/360)
 
 # v1.6.0 (2026-06-25)
 


### PR DESCRIPTION
This sets the stack size on Windows targets to 8 MiB, which is the default on linux.