### PR TITLE
Add a GitHub Action for WuppieFuzz

### DIFF
--- a/.github/action-test/openapi.yaml
+++ b/.github/action-test/openapi.yaml
@@ -7,9 +7,65 @@ servers:
 paths:
   /get:
     get:
+      parameters:
+        - name: query
+          in: query
+          schema:
+            type: string
+            example: smoke-test
       responses:
         "200":
           description: JSON response
           content:
             application/json:
               schema: true
+  /anything/{value}:
+    get:
+      parameters:
+        - name: value
+          in: path
+          required: true
+          schema:
+            type: string
+            example: smoke-test
+        - name: detail
+          in: query
+          schema:
+            type: boolean
+            example: true
+      responses:
+        "200":
+          description: Request details
+          content:
+            application/json:
+              schema: true
+  /anything/post:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - message
+              properties:
+                message:
+                  type: string
+                  example: smoke-test
+      responses:
+        "200":
+          description: Posted request details
+          content:
+            application/json:
+              schema: true
+  /status/201:
+    get:
+      responses:
+        "201":
+          description: Created
+  /status/418:
+    get:
+      responses:
+        "418":
+          description: Teapot

--- a/.github/action-test/openapi.yaml
+++ b/.github/action-test/openapi.yaml
@@ -1,0 +1,15 @@
+openapi: 3.1.0
+info:
+  title: WuppieFuzz Action smoke test
+  version: 1.0.0
+servers:
+  - url: http://127.0.0.1:8080
+paths:
+  /get:
+    get:
+      responses:
+        "200":
+          description: JSON response
+          content:
+            application/json:
+              schema: true

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           openapi-spec: .github/action-test/openapi.yaml
           docker-image: docker.io/mccutchen/go-httpbin@sha256:24528cf5229d0b70065ac27e6c9e4d96f5452a84a3ce4433e56573c18d96827a
-          timeout: "1"
+          timeout: "10"
           startup-wait: "1"
           artifact-name: wuppiefuzz-action-smoke-test
 
@@ -37,4 +37,53 @@ jobs:
           RESULTS_PATH: ${{ steps.fuzz.outputs.results-path }}
         run: |
           test -s "$RESULTS_PATH/target-container.log"
-          test -d "$RESULTS_PATH/reports"
+          python3 - "$RESULTS_PATH/reports/grafana/report.db" <<'PY'
+          import sqlite3
+          import sys
+
+          expected = {
+              ("GET", "/get", 200),
+              ("GET", "/anything/{value}", 200),
+              ("POST", "/anything/post", 200),
+              ("GET", "/status/201", 201),
+              ("GET", "/status/418", 418),
+          }
+
+          with sqlite3.connect(sys.argv[1]) as database:
+              observed = set(database.execute("""
+                  SELECT DISTINCT requests.type, requests.path, responses.status
+                  FROM requests
+                  JOIN responses ON responses.reqid = requests.id
+                  WHERE responses.status IS NOT NULL
+              """))
+              coverage = database.execute("""
+                  SELECT MAX(endpoint_coverage), MAX(endpoint_coverage_total)
+                  FROM coverage
+              """).fetchone()
+              performance = database.execute("""
+                  SELECT seq_per_sec, req_per_sec
+                  FROM stats
+                  ORDER BY id DESC
+                  LIMIT 1
+              """).fetchone()
+
+          missing = expected - observed
+          if missing:
+              raise SystemExit(f"Missing method/path/status combinations: {sorted(missing)}")
+          if coverage != (len(expected), len(expected)):
+              raise SystemExit(f"Expected endpoint coverage 5/5, got {coverage[0]}/{coverage[1]}")
+          if performance is None:
+              raise SystemExit("No performance statistics were recorded")
+
+          seq_per_sec, req_per_sec = performance
+          if seq_per_sec < 10 or req_per_sec < 10:
+              raise SystemExit(
+                  f"Performance below smoke-test floor: {seq_per_sec:.1f} seq/s, "
+                  f"{req_per_sec:.1f} req/s"
+              )
+
+          print(
+              f"Validated {len(expected)} method/path/status combinations, "
+              f"5/5 endpoint coverage, {seq_per_sec:.1f} seq/s, and {req_per_sec:.1f} req/s"
+          )
+          PY

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -1,0 +1,40 @@
+name: GitHub Action smoke test
+
+on:
+  pull_request:
+    paths:
+      - action.yml
+      - action/**
+      - .github/action-test/**
+      - .github/workflows/github-action.yml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Fuzz httpbin
+        id: fuzz
+        uses: ./
+        with:
+          openapi-spec: .github/action-test/openapi.yaml
+          docker-image: docker.io/mccutchen/go-httpbin@sha256:24528cf5229d0b70065ac27e6c9e4d96f5452a84a3ce4433e56573c18d96827a
+          timeout: "1"
+          startup-wait: "1"
+          artifact-name: wuppiefuzz-action-smoke-test
+
+      - name: Verify generated results
+        env:
+          RESULTS_PATH: ${{ steps.fuzz.outputs.results-path }}
+        run: |
+          test -s "$RESULTS_PATH/target-container.log"
+          test -d "$RESULTS_PATH/reports"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,37 @@ Third-party license notices are listed in [THIRD_PARTY_NOTICES](THIRD_PARTY_NOTI
 For quick installation of WuppieFuzz for popular operating systems (MacOS,
 Windows, Linux) see [releases](https://github.com/TNO-S3/WuppieFuzz/releases/) or use [`brew install wuppiefuzz`](https://formulae.brew.sh/formula/wuppiefuzz)
 
+## GitHub Action
+
+The WuppieFuzz Action starts a self-contained API image, fuzzes it using an
+OpenAPI specification from your repository, and uploads the reports and target
+logs as a workflow artifact. After the Action is released, use its major version
+tag:
+
+```yaml
+permissions:
+  contents: read
+
+steps:
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    with:
+      persist-credentials: false
+  - uses: TNO-S3/WuppieFuzz@v1
+    with:
+      openapi-spec: openapi.yaml
+      docker-image: ghcr.io/example/my-api:latest
+      timeout: "300"
+```
+
+The Action requires a Linux runner with Docker. The target image must start
+without additional commands and listen on the host and port named by the
+specification's `servers` URL, normally `localhost`. Log in to private container
+registries before invoking the Action.
+
+Optional inputs control the fuzzing `timeout`, `startup-wait`, `artifact-name`,
+and `wuppiefuzz-version`. The `results-path` output points to the generated files
+for later workflow steps; the Action also uploads them automatically.
+
 ### Short how-to
 
 [![How to use WuppieFuzz? - YouTube](./assets/demo_video.png)](https://www.youtube.com/watch?v=-oR4d9aXrqo)

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ without additional commands and listen on the host and port named by the
 specification's `servers` URL, normally `localhost`. Log in to private container
 registries before invoking the Action.
 
-Optional inputs control the fuzzing `timeout`, `startup-wait`, `artifact-name`,
-and `wuppiefuzz-version`. The `results-path` output points to the generated files
-for later workflow steps; the Action also uploads them automatically.
+Optional inputs control the fuzzing `timeout`, `startup-wait`, and
+`artifact-name`. The `results-path` output points to the generated files for
+later workflow steps; the Action also uploads them automatically.
 
 ### Short how-to
 

--- a/action.yml
+++ b/action.yml
@@ -15,20 +15,13 @@ inputs:
     required: true
   timeout:
     description: Fuzzing duration in seconds
-    required: false
     default: "60"
   startup-wait:
     description: Maximum startup wait in seconds
-    required: false
     default: "10"
   artifact-name:
     description: Name of the uploaded results artifact
-    required: false
     default: wuppiefuzz-report
-  wuppiefuzz-version:
-    description: WuppieFuzz release version; defaults to the version in Cargo.toml
-    required: false
-    default: ""
 
 outputs:
   results-path:
@@ -46,7 +39,6 @@ runs:
         INPUT_DOCKER_IMAGE: ${{ inputs.docker-image }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_STARTUP_WAIT: ${{ inputs.startup-wait }}
-        INPUT_WUPPIEFUZZ_VERSION: ${{ inputs.wuppiefuzz-version }}
       run: "${GITHUB_ACTION_PATH}/action/run.sh"
 
     - name: Upload WuppieFuzz results

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,58 @@
+name: WuppieFuzz API fuzzing
+description: Run WuppieFuzz against an API in a Docker image
+author: TNO Software and System Security
+
+branding:
+  icon: shield
+  color: purple
+
+inputs:
+  openapi-spec:
+    description: Path to the OpenAPI specification in the checked-out repository
+    required: true
+  docker-image:
+    description: Self-starting Docker image containing the API to fuzz
+    required: true
+  timeout:
+    description: Fuzzing duration in seconds
+    required: false
+    default: "60"
+  startup-wait:
+    description: Maximum startup wait in seconds
+    required: false
+    default: "10"
+  artifact-name:
+    description: Name of the uploaded results artifact
+    required: false
+    default: wuppiefuzz-report
+  wuppiefuzz-version:
+    description: WuppieFuzz release version; defaults to the version in Cargo.toml
+    required: false
+    default: ""
+
+outputs:
+  results-path:
+    description: Directory containing WuppieFuzz reports, crashes, and target logs
+    value: ${{ steps.fuzz.outputs.results-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run WuppieFuzz
+      id: fuzz
+      shell: bash
+      env:
+        INPUT_OPENAPI_SPEC: ${{ inputs.openapi-spec }}
+        INPUT_DOCKER_IMAGE: ${{ inputs.docker-image }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_STARTUP_WAIT: ${{ inputs.startup-wait }}
+        INPUT_WUPPIEFUZZ_VERSION: ${{ inputs.wuppiefuzz-version }}
+      run: "${GITHUB_ACTION_PATH}/action/run.sh"
+
+    - name: Upload WuppieFuzz results
+      if: ${{ always() && steps.fuzz.outputs.results-path != '' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ steps.fuzz.outputs.results-path }}
+        if-no-files-found: error

--- a/action/run.sh
+++ b/action/run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail() {
+    echo "WuppieFuzz Action: $*" >&2
+    exit 1
+}
+
+[[ "${RUNNER_OS:-}" == "Linux" ]] || fail "only Linux runners are supported"
+command -v curl >/dev/null || fail "curl is required"
+command -v docker >/dev/null || fail "Docker is required"
+command -v sha256sum >/dev/null || fail "sha256sum is required"
+
+[[ -n "${INPUT_OPENAPI_SPEC:-}" ]] || fail "openapi-spec is required"
+[[ -n "${INPUT_DOCKER_IMAGE:-}" ]] || fail "docker-image is required"
+[[ "${INPUT_TIMEOUT:-}" =~ ^[1-9][0-9]*$ ]] || fail "timeout must be a positive integer"
+[[ "${INPUT_STARTUP_WAIT:-}" =~ ^[0-9]+$ ]] || fail "startup-wait must be a non-negative integer"
+
+if [[ "$INPUT_OPENAPI_SPEC" = /* ]]; then
+    spec_path="$INPUT_OPENAPI_SPEC"
+else
+    spec_path="${GITHUB_WORKSPACE:?}/${INPUT_OPENAPI_SPEC}"
+fi
+[[ -f "$spec_path" ]] || fail "OpenAPI specification not found: $spec_path"
+spec_path="$(realpath "$spec_path")"
+
+version="${INPUT_WUPPIEFUZZ_VERSION#v}"
+if [[ -z "$version" ]]; then
+    version="$(awk -F '"' '/^version = "/ { print $2; exit }' "${GITHUB_ACTION_PATH:?}/Cargo.toml")"
+fi
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?$ ]] \
+    || fail "invalid WuppieFuzz version: $version"
+
+case "$(uname -m)" in
+    x86_64 | amd64) target="x86_64-unknown-linux-gnu" ;;
+    aarch64 | arm64) target="aarch64-unknown-linux-gnu" ;;
+    *) fail "unsupported runner architecture: $(uname -m)" ;;
+esac
+
+run_key="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-${BASHPID}"
+work_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/wuppiefuzz-action.XXXXXX")"
+results_dir="${RUNNER_TEMP:-/tmp}/wuppiefuzz-results-${run_key}"
+run_dir="${work_dir}/run"
+install_dir="${work_dir}/install"
+container_id=""
+mkdir -p "$results_dir" "$run_dir" "$install_dir"
+touch "$results_dir/target-container.log"
+echo "results-path=$results_dir" >> "${GITHUB_OUTPUT:?}"
+
+cleanup() {
+    status=$?
+    trap - EXIT
+    set +e
+
+    if [[ -n "$container_id" ]] && docker inspect "$container_id" >/dev/null 2>&1; then
+        # ponytail: keep CI artifacts bounded; make this configurable if full logs are needed.
+        docker logs --tail 1000 "$container_id" > "$results_dir/target-container.log" 2>&1
+        docker rm --force "$container_id" >/dev/null
+    fi
+    for directory in reports crashes; do
+        if [[ -e "$run_dir/$directory" ]]; then
+            cp -a "$run_dir/$directory" "$results_dir/" || status=1
+        fi
+    done
+
+    exit "$status"
+}
+trap cleanup EXIT
+
+archive="wuppiefuzz-${target}.tar.xz"
+release_url="https://github.com/TNO-S3/WuppieFuzz/releases/download/v${version}"
+curl --fail --location --retry 3 --show-error --silent \
+    --output "$install_dir/$archive" "$release_url/$archive"
+curl --fail --location --retry 3 --show-error --silent \
+    --output "$install_dir/$archive.sha256" "$release_url/$archive.sha256"
+(
+    cd "$install_dir"
+    sha256sum --check "$archive.sha256"
+)
+tar --extract --xz --file "$install_dir/$archive" --directory "$install_dir" \
+    --strip-components 1
+wuppiefuzz="$install_dir/wuppiefuzz"
+[[ -x "$wuppiefuzz" ]] || fail "release archive did not contain the WuppieFuzz executable"
+
+docker pull "$INPUT_DOCKER_IMAGE"
+container_id="$(docker run --detach --network host "$INPUT_DOCKER_IMAGE")"
+
+elapsed=0
+while ((elapsed < INPUT_STARTUP_WAIT)); do
+    [[ "$(docker inspect --format '{{.State.Running}}' "$container_id")" == "true" ]] \
+        || fail "target container stopped during startup"
+    health="$(docker inspect \
+        --format '{{if .Config.Healthcheck}}{{.State.Health.Status}}{{else}}none{{end}}' \
+        "$container_id")"
+    case "$health" in
+        healthy) break ;;
+        unhealthy) fail "target container reported an unhealthy status" ;;
+    esac
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+[[ "$(docker inspect --format '{{.State.Running}}' "$container_id")" == "true" ]] \
+    || fail "target container is not running"
+health="$(docker inspect \
+    --format '{{if .Config.Healthcheck}}{{.State.Health.Status}}{{else}}none{{end}}' \
+    "$container_id")"
+[[ "$health" != "starting" ]] \
+    || fail "target container did not become healthy within ${INPUT_STARTUP_WAIT} seconds"
+
+cd "$run_dir"
+"$wuppiefuzz" fuzz --log-level warn --report --timeout "$INPUT_TIMEOUT" "$spec_path"

--- a/action/run.sh
+++ b/action/run.sh
@@ -24,12 +24,8 @@ fi
 [[ -f "$spec_path" ]] || fail "OpenAPI specification not found: $spec_path"
 spec_path="$(realpath "$spec_path")"
 
-version="${INPUT_WUPPIEFUZZ_VERSION#v}"
-if [[ -z "$version" ]]; then
-    version="$(awk -F '"' '/^version = "/ { print $2; exit }' "${GITHUB_ACTION_PATH:?}/Cargo.toml")"
-fi
-[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?$ ]] \
-    || fail "invalid WuppieFuzz version: $version"
+version="$(awk -F '"' '/^version = "/ { print $2; exit }' "${GITHUB_ACTION_PATH:?}/Cargo.toml")"
+[[ -n "$version" ]] || fail "could not determine WuppieFuzz version from Cargo.toml"
 
 case "$(uname -m)" in
     x86_64 | amd64) target="x86_64-unknown-linux-gnu" ;;
@@ -59,9 +55,10 @@ cleanup() {
     fi
     for directory in reports crashes; do
         if [[ -e "$run_dir/$directory" ]]; then
-            cp -a "$run_dir/$directory" "$results_dir/" || status=1
+            mv "$run_dir/$directory" "$results_dir/" || status=1
         fi
     done
+    rm -rf -- "$work_dir" || status=1
 
     exit "$status"
 }


### PR DESCRIPTION
## Summary

- add a composite Action accepting an OpenAPI specification and Docker image
- start, health-check, fuzz, clean up, and upload reports, crashes, and bounded target logs
- document usage and add a pinned end-to-end smoke test

## Validation

- end-to-end action smoke run
- actionlint and ShellCheck
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace --verbose (70 passed)

Closes #92