### PR TITLE
Make server-error crash policy OpenAPI-aware and configurable

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -17,6 +17,7 @@ use crate::openapi::validate_response::ValidationErrorDiscriminants;
 const DEFAULT_REQUEST_TIMEOUT: u64 = 30000;
 const DEFAULT_METHOD_MUTATION_STRATEGY: MethodMutationStrategy = MethodMutationStrategy::FollowSpec;
 const DEFAULT_LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
+const DEFAULT_ALWAYS_CRASH_STATUS_CODES: [u16; 2] = [500, 502];
 
 lazy_static! {
     static ref CONFIGURATION: Result<Configuration, anyhow::Error> =
@@ -124,6 +125,17 @@ pub enum Commands {
         /// By default, all validation error variants are considered crashes.
         #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]
         crash_criteria: Option<Vec<ValidationErrorDiscriminants>>,
+        /// Status codes that always count as bugs, even when documented in OpenAPI.
+        /// Defaults to 500 and 502. Pass this flag without values to disable the override.
+        #[arg(
+            long,
+            value_delimiter = ',',
+            num_args = 0..,
+            require_equals = true,
+            value_parser = clap::value_parser!(u16).range(100..=999),
+            value_name = "STATUS"
+        )]
+        always_crash_status_codes: Option<Vec<u16>>,
         // Manually added possible values below, since automatically showing possible values of an external (remote) enum
         // such as log::LevelFilter is not well supported.
         // See https://github.com/serde-rs/serde/issues/1301, https://github.com/serde-rs/serde/issues/723
@@ -201,6 +213,18 @@ pub enum Commands {
             verbatim_doc_comment
         )]
         crash_criteria: Option<Vec<ValidationErrorDiscriminants>>,
+
+        /// Status codes that always count as bugs, even when documented in OpenAPI.
+        /// Defaults to 500 and 502. Pass this flag without values to disable the override.
+        #[arg(
+            long,
+            value_delimiter = ',',
+            num_args = 0..,
+            require_equals = true,
+            value_parser = clap::value_parser!(u16).range(100..=999),
+            value_name = "STATUS"
+        )]
+        always_crash_status_codes: Option<Vec<u16>>,
 
         /// If present, ask the coverage monitor to generate a report after the
         /// time-out passes
@@ -290,6 +314,7 @@ impl Commands {
                 authentication,
                 header,
                 crash_criteria,
+                always_crash_status_codes,
                 log_level,
                 ..
             } => Ok(PartialConfiguration {
@@ -298,6 +323,7 @@ impl Commands {
                 authentication,
                 header,
                 crash_criteria,
+                always_crash_status_codes,
                 log_level,
                 ..Default::default()
             }),
@@ -311,6 +337,7 @@ impl Commands {
                 request_timeout,
                 power_schedule,
                 crash_criteria,
+                always_crash_status_codes,
                 report,
                 method_mutation_strategy,
                 jacoco_class_dir,
@@ -331,6 +358,7 @@ impl Commands {
                 request_timeout,
                 power_schedule,
                 crash_criteria,
+                always_crash_status_codes,
                 report,
                 method_mutation_strategy,
                 jacoco_class_dir,
@@ -407,9 +435,19 @@ struct PartialConfiguration {
     #[arg(value_parser, long, value_enum, required = false, ignore_case = true)]
     pub power_schedule: Option<BaseSchedule>,
 
-    /// Which errors the fuzzer considers a bug.
+    /// Which validation errors the fuzzer considers a bug.
     #[clap(value_parser, long, value_enum, required = false, ignore_case = true)]
     pub crash_criteria: Option<Vec<ValidationErrorDiscriminants>>,
+
+    /// Status codes that always count as bugs, even when documented in OpenAPI.
+    #[clap(
+        long,
+        value_delimiter = ',',
+        num_args = 0..,
+        require_equals = true,
+        value_parser = clap::value_parser!(u16).range(100..=999)
+    )]
+    pub always_crash_status_codes: Option<Vec<u16>>,
 
     /// If present, ask the coverage monitor to generate a report after the
     /// time-out passes
@@ -530,10 +568,13 @@ pub struct Configuration {
     /// The power schedule to use for prioritizing seeds.
     pub power_schedule: BaseSchedule,
 
-    /// Which errors the fuzzer considers a bug. By default, the value for this
+    /// Which validation errors the fuzzer considers a bug. By default, the value for this
     /// option is a list of all validation error variants. By specifying a subset
     /// you can configure what behaviour is considered a bug by the fuzzer.
     pub crash_criteria: Vec<ValidationErrorDiscriminants>,
+
+    /// Status codes that always count as bugs, even when documented in OpenAPI.
+    pub always_crash_status_codes: Vec<u16>,
 
     /// If present, ask the coverage monitor to generate a report after the
     /// time-out passes.
@@ -609,6 +650,14 @@ impl TryFrom<PartialConfiguration> for Configuration {
     type Error = anyhow::Error;
 
     fn try_from(value: PartialConfiguration) -> Result<Self, Self::Error> {
+        if let Some(invalid_status) = value
+            .always_crash_status_codes
+            .as_ref()
+            .and_then(|codes| codes.iter().find(|&&status| !(100..=999).contains(&status)))
+        {
+            bail!("Invalid always-crash HTTP status code {invalid_status}; expected 100..=999");
+        }
+
         if value.report.unwrap_or(false) {
             if value.coverage_format == Some(CoverageFormat::Jacoco)
                 && value.jacoco_class_dir.is_none()
@@ -653,6 +702,9 @@ impl TryFrom<PartialConfiguration> for Configuration {
             crash_criteria: value
                 .crash_criteria
                 .unwrap_or_else(|| ValidationErrorDiscriminants::VARIANTS.to_vec()),
+            always_crash_status_codes: value
+                .always_crash_status_codes
+                .unwrap_or_else(|| DEFAULT_ALWAYS_CRASH_STATUS_CODES.to_vec()),
             report: value.report.unwrap_or(false),
             method_mutation_strategy: value
                 .method_mutation_strategy
@@ -702,6 +754,9 @@ impl PartialConfiguration {
             request_timeout: other.request_timeout.or(self.request_timeout.take()),
             power_schedule: other.power_schedule.or(self.power_schedule.take()),
             crash_criteria: other.crash_criteria.or(self.crash_criteria.take()),
+            always_crash_status_codes: other
+                .always_crash_status_codes
+                .or(self.always_crash_status_codes.take()),
             report: other.report.or(self.report.take()),
             method_mutation_strategy: other
                 .method_mutation_strategy
@@ -755,8 +810,10 @@ fn verify_url(arg: &str) -> anyhow::Result<Url> {
 mod tests {
     use std::{convert::TryInto, num::NonZeroU64};
 
+    use clap::Parser;
+
     use super::{
-        Configuration, CoverageConfiguration, CoverageFormat, DEFAULT_REQUEST_TIMEOUT,
+        Cli, Configuration, CoverageConfiguration, CoverageFormat, DEFAULT_REQUEST_TIMEOUT,
         OutputFormat, PartialConfiguration, parse_socket_addr,
     };
 
@@ -787,7 +844,55 @@ mod tests {
 
         assert_eq!(tried_config.request_timeout, DEFAULT_REQUEST_TIMEOUT);
         assert_eq!(tried_config.log_level, log::LevelFilter::Info);
-        assert_eq!(tried_config.coverage_configuration, coverage_config)
+        assert_eq!(tried_config.coverage_configuration, coverage_config);
+        assert_eq!(tried_config.always_crash_status_codes, vec![500, 502]);
+    }
+
+    #[test]
+    fn test_always_crash_status_codes() {
+        let cli = Cli::try_parse_from([
+            "wuppiefuzz",
+            "fuzz",
+            "open_api.yaml",
+            "--always-crash-status-codes=500,529",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.command
+                .fuzzer_config()
+                .unwrap()
+                .always_crash_status_codes,
+            Some(vec![500, 529])
+        );
+
+        let cli = Cli::try_parse_from([
+            "wuppiefuzz",
+            "fuzz",
+            "open_api.yaml",
+            "--always-crash-status-codes",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.command
+                .fuzzer_config()
+                .unwrap()
+                .always_crash_status_codes,
+            Some(vec![])
+        );
+
+        let invalid: Result<Configuration, _> = PartialConfiguration {
+            openapi_spec: Some("open_api.yaml".into()),
+            always_crash_status_codes: Some(vec![99]),
+            ..Default::default()
+        }
+        .try_into();
+        match invalid {
+            Ok(_) => panic!("Invalid always-crash status code was accepted"),
+            Err(error) => assert_eq!(
+                error.to_string(),
+                "Invalid always-crash HTTP status code 99; expected 100..=999"
+            ),
+        }
     }
 
     #[test]
@@ -864,6 +969,7 @@ mod tests {
             coverage_host: Some(parse_socket_addr("127.0.0.1:6300").unwrap()),
             timeout: NonZeroU64::new(60000),
             request_timeout: Some(10000),
+            always_crash_status_codes: Some(vec![500, 502]),
             output_format: Some(OutputFormat::HumanReadable),
             ..Default::default()
         };
@@ -871,6 +977,7 @@ mod tests {
         let cli_config: PartialConfiguration = PartialConfiguration {
             openapi_spec: Some("open_api.yaml".into()),
             timeout: NonZeroU64::new(30000),
+            always_crash_status_codes: Some(vec![]),
             output_format: Some(OutputFormat::Json),
             ..Default::default()
         };
@@ -880,6 +987,7 @@ mod tests {
             coverage_host: Some(parse_socket_addr("127.0.0.1:6300").unwrap()),
             timeout: NonZeroU64::new(30000),
             request_timeout: Some(10000),
+            always_crash_status_codes: Some(vec![]),
             output_format: Some(OutputFormat::Json),
             ..Default::default()
         };

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -107,20 +107,22 @@ pub(crate) fn process_response(
     request: &OpenApiRequest,
     response: &Response,
     api: &Spec,
-    crash_criteria: &[ValidationErrorDiscriminants],
+    crash_policy: (&[ValidationErrorDiscriminants], &[u16]),
     exit_kind: &mut ExitKind,
     parameter_feedback: &mut ParameterFeedback,
 ) -> Option<ValidationError> {
+    let (crash_criteria, always_crash_status_codes) = crash_policy;
     if response.status() == 429 {
         log::warn!("HTTP status 429 'Too Many Requests' encountered!");
         log::warn!("Rate limiting is likely active on the program under test.");
         log::warn!("This hinders fuzz testing. Consider disabling it.");
     }
     let mut maybe_validation_error = None;
-    if response.status().is_server_error() {
+    if always_crash_status_codes.contains(&response.status().as_u16()) {
         *exit_kind = ExitKind::Crash;
         log::debug!(
-            "OpenAPI-input resulted in server error response, ignoring rest of request chain."
+            "HTTP status {} is always considered a crash, ignoring rest of request chain.",
+            response.status()
         );
     } else if let Err(validation_err) = validate_response(api, request, response)
         && crash_criteria.contains(&validation_err.discriminant())
@@ -317,7 +319,10 @@ where
                         &request,
                         &response,
                         self.api,
-                        &self.config.crash_criteria,
+                        (
+                            &self.config.crash_criteria,
+                            &self.config.always_crash_status_codes,
+                        ),
                         &mut exit_kind,
                         &mut parameter_feedback,
                     );

--- a/src/openapi/validate_response.rs
+++ b/src/openapi/validate_response.rs
@@ -634,11 +634,17 @@ fn validate_object_against_type(
 }
 
 #[cfg(test)]
-mod injection_signature_tests {
+mod tests {
     use std::collections::BTreeMap;
 
+    use libafl::executors::ExitKind;
+
     use super::*;
-    use crate::input::{Body, Method, ParameterContents, parameter::SimpleValue};
+    use crate::{
+        executor::process_response,
+        input::{Body, Method, ParameterContents, parameter::SimpleValue},
+        parameter_feedback::ParameterFeedback,
+    };
 
     fn response_with_body(status: StatusCode, body: &str) -> Response {
         Response {
@@ -657,6 +663,96 @@ mod injection_signature_tests {
             ))),
             parameters: BTreeMap::new(),
         }
+    }
+
+    fn server_error_spec() -> Spec {
+        let spec: oas3::Spec = oas3::from_yaml(
+            r#"
+openapi: 3.1.0
+info:
+  title: Server error test
+  version: "1.0"
+paths:
+  /documented:
+    post:
+      responses:
+        "500": { description: Internal Server Error }
+        "502": { description: Bad Gateway }
+        "529": { description: Site is overloaded }
+  /undocumented:
+    post:
+      responses:
+        "200": { description: Success }
+"#,
+        )
+        .unwrap();
+        spec.into()
+    }
+
+    fn process_status(
+        api: &Spec,
+        path: &str,
+        status: StatusCode,
+        crash_criteria: &[ValidationErrorDiscriminants],
+        always_crash_status_codes: &[u16],
+    ) -> ExitKind {
+        let mut request = request_with_body_string("hello");
+        request.path = path.to_string();
+        let response = response_with_body(status, "");
+        let mut exit_kind = ExitKind::Ok;
+        let mut parameter_feedback = ParameterFeedback::new(1);
+
+        process_response(
+            0,
+            &request,
+            &response,
+            api,
+            (crash_criteria, always_crash_status_codes),
+            &mut exit_kind,
+            &mut parameter_feedback,
+        );
+
+        exit_kind
+    }
+
+    #[test]
+    fn classifies_server_errors_using_policy_and_openapi() {
+        let api = server_error_spec();
+
+        for status in [StatusCode::INTERNAL_SERVER_ERROR, StatusCode::BAD_GATEWAY] {
+            assert_eq!(
+                process_status(&api, "/documented", status, &[], &[500, 502]),
+                ExitKind::Crash
+            );
+        }
+
+        let status_529 = StatusCode::from_u16(529).unwrap();
+        assert_eq!(
+            process_status(&api, "/documented", status_529, &[], &[500, 502]),
+            ExitKind::Ok
+        );
+        assert_eq!(
+            process_status(
+                &api,
+                "/undocumented",
+                status_529,
+                &[ValidationErrorDiscriminants::Status5xxNotSpecified],
+                &[500, 502],
+            ),
+            ExitKind::Crash
+        );
+        assert_eq!(
+            process_status(&api, "/undocumented", status_529, &[], &[500, 502]),
+            ExitKind::Ok
+        );
+        assert_eq!(
+            process_status(&api, "/documented", StatusCode::BAD_GATEWAY, &[], &[],),
+            ExitKind::Ok
+        );
+        assert_eq!(
+            process_status(&api, "/documented", status_529, &[], &[529]),
+            ExitKind::Crash
+        );
     }
 
     #[test]

--- a/src/reproducer.rs
+++ b/src/reproducer.rs
@@ -98,7 +98,7 @@ pub fn reproduce(input_file: &Path) -> Result<()> {
                     &request,
                     &response,
                     &api,
-                    &config.crash_criteria,
+                    (&config.crash_criteria, &config.always_crash_status_codes),
                     &mut exit_kind,
                     &mut parameter_feedback,
                 );


### PR DESCRIPTION
Closes #93.

## Problem

WuppieFuzz currently treats every 5xx response as an immediate crash. This happens before OpenAPI validation. A documented 529 therefore crashes even when the API declares it as expected behavior.

## Solution

- Treat 500 and 502 as crashes by default.
- Send other responses through the existing OpenAPI validation.
- Add a configurable `always_crash_status_codes` list.
- Use the same policy during fuzzing and reproduction.

A documented 529 is now accepted by default. An undocumented 529 still triggers `Status5xxNotSpecified`.

Users can replace the default list:

```text
--always-crash-status-codes=500,529
```

They can also disable the override with an empty list.

## Design

The issue raised two needs. Expected responses should follow the OpenAPI specification. Strong crash signals should still be reportable regardless of the specification.

I looked at other API fuzzers to see how they handle this distinction. [RESTler](https://github.com/microsoft/restler-fuzzer/blob/6d984deedbc54aad957fa3da0c7e9e5df23a2aee/docs/user-guide/SettingsFile.md#L106-L124) makes bug status rules configurable. [Schemathesis](https://github.com/schemathesis/schemathesis/blob/04e479b80a94afb4d24e192e75b891d8df479eb9/docs/reference/checks.md#L48-L77) separates server-error detection from OpenAPI status conformance.

This change follows the same separation. OpenAPI determines whether a response is expected. The explicit status list determines which responses always count as bugs.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 72 passed
