### PR TITLE
Add TraceGeneric coverage client for the AFL-like bitmap wire protocol

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -159,7 +159,7 @@ pub enum Commands {
         coverage_host: Option<SocketAddr>,
 
         /// The format in which your instrumentation provides coverage information.
-        /// Must be one of {'jacoco', 'lcov', 'coverband'}. If omitted, the fuzzer will use
+        /// Must be one of {'jacoco', 'lcov', 'coverband', 'trace-generic'}. If omitted, the fuzzer will use
         /// endpoint coverage only.
         #[arg(value_parser, long, value_enum, ignore_case = true)]
         coverage_format: Option<CoverageFormat>,
@@ -389,7 +389,7 @@ struct PartialConfiguration {
     pub coverage_host: Option<SocketAddr>,
 
     /// The format in which your instrumentation provides coverage information.
-    /// Must be one of {'jacoco', 'lcov', 'coverband'}. If omitted, the fuzzer will use
+    /// Must be one of {'jacoco', 'lcov', 'coverband', 'trace-generic'}. If omitted, the fuzzer will use
     /// endpoint coverage only.
     #[clap(value_parser, long, value_enum, ignore_case = true)]
     pub coverage_format: Option<CoverageFormat>,
@@ -473,6 +473,8 @@ pub enum CoverageFormat {
     Lcov,
     #[serde(alias = "coverband")]
     Coverband,
+    #[serde(alias = "trace-generic", alias = "trace_generic")]
+    TraceGeneric,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum, Deserialize)]
@@ -516,7 +518,7 @@ pub struct Configuration {
     pub coverage_host: Option<SocketAddr>,
 
     /// The format in which your instrumentation provides coverage information.
-    /// Must be one of {'jacoco', 'lcov', 'coverband'}. If omitted, the fuzzer will use
+    /// Must be one of {'jacoco', 'lcov', 'coverband', 'trace-generic'}. If omitted, the fuzzer will use
     /// endpoint coverage only.
     pub coverage_configuration: CoverageConfiguration,
 
@@ -579,6 +581,10 @@ pub enum CoverageConfiguration {
     },
     /// Coverband coverage. Requires a source directory if a report needs to be generated.
     Coverband { source_dir: Option<PathBuf> },
+    /// TraceGeneric coverage. Receives a raw 8-bit AFL-like coverage bitmap over the
+    /// wire protocol; no edge-to-source mapping is available, so
+    /// coverage reports are not supported.
+    TraceGeneric,
 }
 
 impl CoverageConfiguration {
@@ -588,6 +594,7 @@ impl CoverageConfiguration {
             Self::Lcov { .. } => "LCOV",
             Self::Jacoco { .. } => "JaCoCo",
             Self::Coverband { .. } => "Coverband",
+            Self::TraceGeneric => "TraceGeneric",
         }
     }
 }
@@ -615,6 +622,11 @@ impl TryFrom<PartialConfiguration> for Configuration {
             {
                 bail!(
                     "A coverage report is requested for Jacoco coverage, but this requires the jacoco_class_dir parameter to be set",
+                );
+            }
+            if value.coverage_format == Some(CoverageFormat::TraceGeneric) {
+                bail!(
+                    "A coverage report is requested for TraceGeneric coverage, but the TraceGeneric coverage agent carries a raw coverage bitmap with no edge-to-source mapping, so no report can be generated; omit --report or use a different coverage format",
                 );
             }
             if value.coverage_format.is_some() && value.source_dir.is_none() {
@@ -645,6 +657,7 @@ impl TryFrom<PartialConfiguration> for Configuration {
                 Some(CoverageFormat::Coverband) => CoverageConfiguration::Coverband {
                     source_dir: value.source_dir,
                 },
+                Some(CoverageFormat::TraceGeneric) => CoverageConfiguration::TraceGeneric,
                 None => CoverageConfiguration::Endpoint,
             },
             timeout: value.timeout,

--- a/src/coverage_clients/mod.rs
+++ b/src/coverage_clients/mod.rs
@@ -25,6 +25,7 @@ pub mod dummy;
 pub mod endpoint;
 pub mod jacoco;
 pub mod lcov_client;
+pub mod trace_generic;
 
 /// Sets up the line coverage client according to the configuration, and initializes it
 /// and constructs a LibAFL observer and feedback
@@ -108,6 +109,11 @@ pub fn effective_coverage_host(config: &Configuration) -> Option<SocketAddr> {
                 .coverage_host
                 .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001)),
         ),
+        configuration::CoverageConfiguration::TraceGeneric => Some(
+            config
+                .coverage_host
+                .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1337)),
+        ),
         configuration::CoverageConfiguration::Endpoint => None,
     }
 }
@@ -155,6 +161,13 @@ pub fn get_coverage_client<'c>(
                     .context("Could not construct CoverbandCoverageClient")?,
             ))
         }
+        configuration::CoverageConfiguration::TraceGeneric => Box::new(
+            trace_generic::TraceGenericCoverageClient::new(
+                // effective_coverage_host always returns Some for TraceGeneric
+                &coverage_host.unwrap(),
+            )
+            .context("Could not construct TraceGenericCoverageClient")?,
+        ),
         configuration::CoverageConfiguration::Endpoint => {
             Box::new(dummy::DummyCoverageClient::new())
         }

--- a/src/coverage_clients/trace_generic.rs
+++ b/src/coverage_clients/trace_generic.rs
@@ -1,0 +1,151 @@
+//! Coverage client for the TraceGeneric coverage agent, which speaks the WuppieFuzz
+//! The protocol is a generic AFL-like bitmap coverage transport, not tied to any
+//! specific instrumentation or target language.
+
+use std::{
+    io::prelude::*,
+    net::{SocketAddr, TcpStream},
+    path::Path,
+};
+
+use libafl::Error;
+
+use crate::coverage_clients::CoverageClient;
+
+const MAGIC: [u8; 4] = *b"WGCA";
+const VERSION: u8 = 0x01;
+const TYPE_REQUEST_DUMP: u8 = 0x01;
+const TYPE_RESPONSE_DUMP: u8 = 0x02;
+const HEADER_LEN: usize = 10;
+
+/// TraceGeneric coverage client. Communicates with a TraceGeneric coverage agent over a
+/// persistent TCP connection using the wire protocol, receiving a raw 8-bit AFL-like
+/// coverage bitmap whose size is reported by the agent.
+#[derive(Debug)]
+pub struct TraceGenericCoverageClient {
+    cov_map: Vec<u8>,
+    cov_map_total: Vec<u8>,
+    max_ratio: (u64, u64),
+    stream: TcpStream,
+}
+
+impl TraceGenericCoverageClient {
+    /// Creates a new TraceGeneric coverage client connected to the coverage agent at
+    /// `socket_address`.
+    pub fn new(socket_address: &SocketAddr) -> Result<Self, Error> {
+        let stream = TcpStream::connect(socket_address).map_err(|err| {
+            Error::unknown(format!(
+                "Failed to connect TraceGenericCoverageClient to {socket_address}: {err}"
+            ))
+        })?;
+        Ok(Self {
+            cov_map: Vec::new(),
+            cov_map_total: Vec::new(),
+            max_ratio: (0, 0),
+            stream,
+        })
+    }
+
+    /// Sends a `REQUEST_DUMP` and reads back the agent's `RESPONSE_DUMP`, returning the
+    /// raw coverage-map bytes.
+    fn fetch_coverage_internal(&mut self, reset: bool) -> Vec<u8> {
+        let mut request = [0u8; HEADER_LEN + 1];
+        request[0..4].copy_from_slice(&MAGIC);
+        request[4] = VERSION;
+        request[5] = TYPE_REQUEST_DUMP;
+        request[6..10].copy_from_slice(&1u32.to_le_bytes());
+        request[10] = u8::from(reset);
+        self.stream
+            .write_all(&request)
+            .expect("Error writing coverage request");
+        self.stream.flush().expect("Error flushing coverage stream");
+
+        let mut header = [0u8; HEADER_LEN];
+        self.stream
+            .read_exact(&mut header)
+            .expect("No data from coverage client - it may not have started");
+        verify_response_header(&header).expect("Error processing response from coverage agent");
+        let length = u32::from_le_bytes([header[6], header[7], header[8], header[9]]) as usize;
+
+        let mut payload = vec![0u8; length];
+        self.stream
+            .read_exact(&mut payload)
+            .expect("Error reading coverage map");
+        payload
+    }
+}
+
+/// Validates a `RESPONSE_DUMP` header: magic, version, and message type
+fn verify_response_header(header: &[u8; HEADER_LEN]) -> Result<(), Error> {
+    if header[0..4] != MAGIC {
+        return Err(Error::unknown(format!(
+            "Invalid protocol magic in response: {:?}",
+            &header[0..4]
+        )));
+    }
+    if header[4] != VERSION {
+        return Err(Error::unknown(format!(
+            "Unsupported protocol version in response: {}",
+            header[4]
+        )));
+    }
+    if header[5] != TYPE_RESPONSE_DUMP {
+        return Err(Error::unknown(format!(
+            "Unexpected protocol message type in response: {}",
+            header[5]
+        )));
+    }
+    Ok(())
+}
+
+impl CoverageClient for TraceGenericCoverageClient {
+    fn fetch_coverage(&mut self, reset: bool) {
+        let payload = self.fetch_coverage_internal(reset);
+
+        // The coverage-map size is reported by the agent. Allocate the maps once, on the
+        // first non-empty dump; the bitmap size is fixed after initialisation.
+        if !payload.is_empty() && self.cov_map.is_empty() {
+            self.cov_map = vec![0u8; payload.len()];
+            self.cov_map_total = vec![0u8; payload.len()];
+        }
+
+        let n = payload.len().min(self.cov_map.len());
+        for (dst, src) in self.cov_map[..n].iter_mut().zip(payload[..n].iter()) {
+            *dst = u8::from(*src != 0);
+        }
+
+        // merge map with the total coverage map
+        for (dst, src) in self.cov_map_total[..n]
+            .iter_mut()
+            .zip(self.cov_map[..n].iter())
+        {
+            *dst |= src;
+        }
+    }
+
+    fn get_coverage_ptr(&mut self) -> *mut u8 {
+        self.cov_map.as_mut_ptr()
+    }
+
+    /// Returns the coverage-map length reported by the agent, rather than a fixed size.
+    fn get_coverage_len(&self) -> usize {
+        self.cov_map.len()
+    }
+
+    fn max_coverage_ratio(&mut self) -> (u64, u64) {
+        let count = self
+            .cov_map_total
+            .iter()
+            .fold(0u64, |sum, val| sum + u64::from(val.count_ones()));
+        let total = self.cov_map_total.len() as u64;
+        // update the max coverage ratio
+        self.max_ratio.0 = std::cmp::max(self.max_ratio.0, count);
+        self.max_ratio.1 = std::cmp::max(self.max_ratio.1, total);
+        self.max_ratio
+    }
+
+    /// The TraceGeneric payload is a raw coverage bitmap with no edge-to-source mapping,
+    /// so no coverage report can be generated. This is a no-op, matching
+    /// `DummyCoverageClient`.
+    fn generate_coverage_report(&self, _report_path: &Path) {}
+}


### PR DESCRIPTION
Adds a new coverage client that speaks the generic WGCA wire protocol (a persistent-TCP, 10-byte-header frame format carrying a raw 8-bit AFL-like coverage bitmap). The bitmap size is reported by the agent via the RESPONSE_DUMP Length field rather than fixed at compile time.

- New TraceGenericCoverageClient in src/coverage_clients/trace_generic.rs
- CoverageFormat::TraceGeneric / CoverageConfiguration::TraceGeneric wired through configuration, with default port 1337
- Coverage reports are unsupported (raw bitmap has no edge-to-source mapping); --report is rejected for this format