### PR TITLE
Less crash observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Highlights
 
+- Limit INFO logging about new "crashes" being observed. Previously one per line (which flooded the terminal), now reported in aggregate in the heartbeat output. [#372](https://github.com/TNO-S3/WuppieFuzz/pull/372)
+
 ## Features
 
 - Adds support for .NET coverage based on cobertura and dotnet-coverage in [#336](https://github.com/TNO-S3/WuppieFuzz/pull/336)
@@ -9,6 +11,8 @@
 - Adds crash deduplication command in [#334](https://github.com/TNO-S3/WuppieFuzz/pull/334)
 
 ## Fixes
+
+- Harmonizes requests-per-second vs sequences-per-second reporting. Previously the former could be lower than the latter, due to a mismatch in how both were measured. We now do our own bookkeeping for seq/sec reporting as well, ensuring the intuitive constraint that seq/sec > req/sec (a sequence contains at least one request). [#372](https://github.com/TNO-S3/WuppieFuzz/pull/372)
 
 # v1.7.1 (2026-08-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 ## Highlights
 
-- Limit INFO logging about new "crashes" being observed. Previously one per line (which flooded the terminal), now reported in aggregate in the heartbeat output. [#372](https://github.com/TNO-S3/WuppieFuzz/pull/372)
+Limit INFO logging about new "crashes" being observed. Previously one per line (which flooded the terminal), now reported in aggregate in the heartbeat output. Resolves major bug in referencing values.
 
 ## Features
 
 - Adds support for .NET coverage based on cobertura and dotnet-coverage in [#336](https://github.com/TNO-S3/WuppieFuzz/pull/336)
 - Adds support for coverage guidance using OpenTelemetry in [#358](https://github.com/TNO-S3/WuppieFuzz/pull/358)
 - Adds crash deduplication command in [#334](https://github.com/TNO-S3/WuppieFuzz/pull/334)
+- Fix corpus never referencing values from earlier responses in [#377](https://github.com/TNO-S3/WuppieFuzz/pull/377)
 
 ## Fixes
 
-- Harmonizes requests-per-second vs sequences-per-second reporting. Previously the former could be lower than the latter, due to a mismatch in how both were measured. We now do our own bookkeeping for seq/sec reporting as well, ensuring the intuitive constraint that seq/sec > req/sec (a sequence contains at least one request). [#372](https://github.com/TNO-S3/WuppieFuzz/pull/372)
+- Harmonizes requests-per-second vs sequences-per-second reporting. Previously the former could be lower than the latter, due to a mismatch in how both were measured. We now do our own bookkeeping for seq/sec reporting as well, ensuring the intuitive constraint that seq/sec > req/sec (a sequence contains at least one request) in [#372](https://github.com/TNO-S3/WuppieFuzz/pull/372)
 
 # v1.7.1 (2026-08-26)
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -554,6 +554,13 @@ where
             .duration_since(self.last_window_time)
             .as_secs();
         if diff > CLIENT_STATS_TIME_WINDOW_SECS {
+            update_stats(
+                state,
+                event_manager,
+                "sequences",
+                UserStatsValue::Number(self.inputs_tested as u64),
+            );
+
             // send the request stats to the event manager for use in the monitor
             update_stats(
                 state,

--- a/src/monitors.rs
+++ b/src/monitors.rs
@@ -40,6 +40,7 @@ where
     client_stats: Vec<ClientStats>,
     execs_per_sec: String,
     last_execs: u64,
+    observed_crashes: u64,
 }
 
 impl<F> Debug for CoverageMonitor<F>
@@ -75,11 +76,18 @@ where
         let execs_per_sec_pretty = global_stats.execs_per_sec_pretty.to_owned();
 
         let client_stats = &client_stats_mgr.client_stats()[&ClientId(0)];
+        if event_msg == "Objective" {
+            self.observed_crashes += 1;
+            return Ok(());
+        }
+        let observed_crashes = self.observed_crashes;
+
         let output_string = match config.output_format {
             OutputFormat::Json => json!({
                 "event_msg": event_msg,
                 "run_time": format_duration(&total_time),
                 "objectives": objective_size,
+                "observed_crashes": observed_crashes,
                 "executed_sequences": total_execs,
                 "sequences_per_sec": self.req_execs_per_sec(total_execs, execs_per_sec_pretty),
                 "requests": Self::req_stats(client_stats, &UserStats::new(UserStatsValue::String(Cow::Borrowed("unknown")), AggregatorOps::None)),
@@ -90,14 +98,7 @@ where
             })
             .to_string(),
             OutputFormat::HumanReadable => {
-            if event_msg == "Objective" {
-                format!(
-                    "[{}] New 'crash' observed! After run time: {}, total number of objectives reached: {}",
-                    event_msg,
-                    format_duration(&total_time),
-                    objective_size,
-                )
-            } else if event_msg == "Testcase" {
+            if event_msg == "Testcase" {
                 match total_execs {
                     0 => format!(
                             "[{event_msg}] Starting corpus loaded! Initial corpus size: {corpus_size}"
@@ -111,11 +112,12 @@ where
                 return Ok(())
             } else {
                 format!(
-                    "[{}] run time: {}, corpus: {}, objectives: {}, executed sequences: {}, seq/sec: {}, requests: {}, req/sec: {}, coverage: {}, endpoint coverage: {}, current sequence: {}",
+                    "[{}] run time: {}, corpus: {}, objectives: {}, observed crashes: {}, executed sequences: {}, seq/sec: {}, requests: {}, req/sec: {}, coverage: {}, endpoint coverage: {}, current sequence: {}",
                     event_msg,
                     format_duration(&total_time),
                     corpus_size,
                     objective_size,
+                    observed_crashes,
                     total_execs,
                     self.req_execs_per_sec(total_execs, execs_per_sec_pretty),
                     Self::req_stats(client_stats, &UserStats::new(UserStatsValue::Number(0), AggregatorOps::None)),
@@ -143,6 +145,7 @@ where
             client_stats: vec![],
             execs_per_sec: "NaN".to_string(),
             last_execs: 0,
+            observed_crashes: 0,
         }
     }
 
@@ -154,6 +157,7 @@ where
             client_stats: vec![],
             execs_per_sec: "NaN".to_string(),
             last_execs: 0,
+            observed_crashes: 0,
         }
     }
 

--- a/src/monitors.rs
+++ b/src/monitors.rs
@@ -38,8 +38,6 @@ where
     print_fn: F,
     start_time: Instant,
     client_stats: Vec<ClientStats>,
-    execs_per_sec: String,
-    last_execs: u64,
     observed_crashes: u64,
 }
 
@@ -73,7 +71,6 @@ where
         let objective_size = global_stats.objective_size;
         let total_execs = global_stats.total_execs;
         let corpus_size = global_stats.corpus_size;
-        let execs_per_sec_pretty = global_stats.execs_per_sec_pretty.to_owned();
 
         let client_stats = &client_stats_mgr.client_stats()[&ClientId(0)];
         if event_msg == "Objective" {
@@ -81,6 +78,8 @@ where
             return Ok(());
         }
         let observed_crashes = self.observed_crashes;
+        let default_sequences = UserStats::new(UserStatsValue::Number(0), AggregatorOps::None);
+        let executed_sequences = Self::seq_stats(client_stats, &default_sequences);
 
         let output_string = match config.output_format {
             OutputFormat::Json => json!({
@@ -88,8 +87,8 @@ where
                 "run_time": format_duration(&total_time),
                 "objectives": objective_size,
                 "observed_crashes": observed_crashes,
-                "executed_sequences": total_execs,
-                "sequences_per_sec": self.req_execs_per_sec(total_execs, execs_per_sec_pretty),
+                "executed_sequences": executed_sequences,
+                "sequences_per_sec": Self::seq_sec_stats(client_stats, total_time.as_secs().try_into().unwrap()),
                 "requests": Self::req_stats(client_stats, &UserStats::new(UserStatsValue::String(Cow::Borrowed("unknown")), AggregatorOps::None)),
                 "requests_per_sec": Self::req_sec_stats(client_stats, &UserStats::new(UserStatsValue::Number(0), AggregatorOps::None), total_time.as_secs().try_into().unwrap()),
                 "coverage": Self::cov_stats(client_stats, &UserStats::new(UserStatsValue::String(Cow::Borrowed("unknown")), AggregatorOps::None)),
@@ -118,8 +117,8 @@ where
                     corpus_size,
                     objective_size,
                     observed_crashes,
-                    total_execs,
-                    self.req_execs_per_sec(total_execs, execs_per_sec_pretty),
+                    executed_sequences,
+                    Self::seq_sec_stats(client_stats, total_time.as_secs().try_into().unwrap()),
                     Self::req_stats(client_stats, &UserStats::new(UserStatsValue::Number(0), AggregatorOps::None)),
                     Self::req_sec_stats(client_stats, &UserStats::new(UserStatsValue::Number(0), AggregatorOps::None), total_time.as_secs().try_into().unwrap()),
                     Self::cov_stats(client_stats, &UserStats::new(UserStatsValue::String(Cow::Borrowed("unknown")), AggregatorOps::None)),
@@ -143,8 +142,6 @@ where
             print_fn,
             start_time: Instant::now(),
             client_stats: vec![],
-            execs_per_sec: "NaN".to_string(),
-            last_execs: 0,
             observed_crashes: 0,
         }
     }
@@ -155,8 +152,6 @@ where
             print_fn,
             start_time,
             client_stats: vec![],
-            execs_per_sec: "NaN".to_string(),
-            last_execs: 0,
             observed_crashes: 0,
         }
     }
@@ -165,12 +160,22 @@ where
         client_stats.get_user_stats("requests").unwrap_or(default)
     }
 
-    fn req_execs_per_sec(&mut self, execs: u64, execs_per_sec_pretty: String) -> String {
-        if self.last_execs < execs {
-            self.execs_per_sec = execs_per_sec_pretty;
-            self.last_execs = execs;
-        }
-        self.execs_per_sec.clone()
+    fn seq_stats<'a>(client_stats: &'a ClientStats, default: &'a UserStats) -> &'a UserStats {
+        client_stats.get_user_stats("sequences").unwrap_or(default)
+    }
+
+    fn seq_sec_stats(client_stats: &ClientStats, secs: usize) -> UserStats {
+        UserStats::new(
+            Self::seq_stats(
+                client_stats,
+                &UserStats::new(UserStatsValue::Number(0), AggregatorOps::None),
+            )
+            .value()
+            .clone()
+            .stats_div(secs)
+            .expect("Something went wrong"),
+            AggregatorOps::None,
+        )
     }
 
     fn req_sec_stats<'a>(


### PR DESCRIPTION
Closes #371 
Closes #373 (with commit `04554f9`)

Report the cumulative number of "crash reports" - previously reported each on its own line - in the heartbeat summary.

In the last commit I also made the reporting of seq/sec use our own counting of inputs, rather than using LibAFL's total_execs. 